### PR TITLE
Add introspection graph domain and service with tests

### DIFF
--- a/src/introspection/graph/domain.rs
+++ b/src/introspection/graph/domain.rs
@@ -1,0 +1,313 @@
+use std::collections::BTreeMap;
+
+/// Represents the full application graph composed of nodes and edges.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationGraph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+/// Describes a vertex in the application graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphNode {
+    pub id: String,
+    pub kind: ComponentKind,
+}
+
+/// Categorises the type of component represented by a [`GraphNode`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComponentKind {
+    Application {
+        name: String,
+    },
+    HttpRoute {
+        path: String,
+        methods: Vec<String>,
+    },
+    BackgroundWorker {
+        name: String,
+        queue: Option<String>,
+    },
+    SchedulerJob {
+        name: String,
+        schedule: String,
+        command: String,
+        run_on_start: bool,
+        shell: bool,
+        tags: Vec<String>,
+    },
+    Task {
+        name: String,
+        detail: Option<String>,
+    },
+}
+
+/// Relationship between two nodes in the application graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphEdge {
+    pub from: String,
+    pub to: String,
+    pub kind: EdgeKind,
+}
+
+/// Describes the semantics of an edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeKind {
+    Contains,
+    Triggers,
+}
+
+impl EdgeKind {
+    fn sort_key(self) -> u8 {
+        match self {
+            Self::Contains => 0,
+            Self::Triggers => 1,
+        }
+    }
+}
+
+/// HTTP route description independent of the framework wiring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDescriptor {
+    pub path: String,
+    pub methods: Vec<String>,
+}
+
+/// Background worker description extracted from queue registries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundWorkerDescriptor {
+    pub name: String,
+    pub queue: Option<String>,
+}
+
+/// Scheduler job description extracted from the scheduler configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchedulerJobDescriptor {
+    pub name: String,
+    pub schedule: String,
+    pub command: String,
+    pub run_on_start: bool,
+    pub shell: bool,
+    pub tags: Vec<String>,
+}
+
+/// Task description exposed by the task registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskDescriptor {
+    pub name: String,
+    pub detail: Option<String>,
+}
+
+/// Repository abstraction for retrieving HTTP routes.
+pub trait RoutesRepository {
+    fn routes(&self) -> Vec<RouteDescriptor>;
+}
+
+/// Repository abstraction for retrieving background workers.
+pub trait BackgroundWorkerRepository {
+    fn workers(&self) -> Vec<BackgroundWorkerDescriptor>;
+}
+
+/// Repository abstraction for retrieving scheduler jobs.
+pub trait SchedulerRepository {
+    fn jobs(&self) -> Vec<SchedulerJobDescriptor>;
+}
+
+/// Repository abstraction for retrieving registered tasks.
+pub trait TaskRepository {
+    fn tasks(&self) -> Vec<TaskDescriptor>;
+}
+
+/// Builds an [`ApplicationGraph`] from the different repositories.
+pub struct GraphBuilder<'a, R, B, S, T>
+where
+    R: RoutesRepository + ?Sized,
+    B: BackgroundWorkerRepository + ?Sized,
+    S: SchedulerRepository + ?Sized,
+    T: TaskRepository + ?Sized,
+{
+    app_name: &'a str,
+    routes: &'a R,
+    background_workers: &'a B,
+    scheduler: &'a S,
+    tasks: &'a T,
+}
+
+impl<'a, R, B, S, T> GraphBuilder<'a, R, B, S, T>
+where
+    R: RoutesRepository + ?Sized,
+    B: BackgroundWorkerRepository + ?Sized,
+    S: SchedulerRepository + ?Sized,
+    T: TaskRepository + ?Sized,
+{
+    /// Creates a new builder referencing the repositories needed to materialise the graph.
+    pub fn new(
+        app_name: &'a str,
+        routes: &'a R,
+        background_workers: &'a B,
+        scheduler: &'a S,
+        tasks: &'a T,
+    ) -> Self {
+        Self {
+            app_name,
+            routes,
+            background_workers,
+            scheduler,
+            tasks,
+        }
+    }
+
+    /// Materialises the graph by querying every repository.
+    #[allow(clippy::too_many_lines)]
+    pub fn build(&self) -> ApplicationGraph {
+        let mut nodes: BTreeMap<String, GraphNode> = BTreeMap::new();
+        let mut edges: Vec<GraphEdge> = Vec::new();
+
+        let root_id = format!("app:{}", self.app_name);
+        nodes.insert(
+            root_id.clone(),
+            GraphNode {
+                id: root_id.clone(),
+                kind: ComponentKind::Application {
+                    name: self.app_name.to_owned(),
+                },
+            },
+        );
+
+        let mut task_nodes: BTreeMap<String, String> = BTreeMap::new();
+        for task in self.tasks.tasks() {
+            let TaskDescriptor { name, detail } = task;
+            let node_id = format!("task:{name}");
+            nodes.insert(
+                node_id.clone(),
+                GraphNode {
+                    id: node_id.clone(),
+                    kind: ComponentKind::Task {
+                        name: name.clone(),
+                        detail,
+                    },
+                },
+            );
+            task_nodes.insert(name, node_id.clone());
+            edges.push(GraphEdge {
+                from: root_id.clone(),
+                to: node_id,
+                kind: EdgeKind::Contains,
+            });
+        }
+
+        for route in self.routes.routes() {
+            let RouteDescriptor { path, mut methods } = route;
+            methods.sort();
+            methods.dedup();
+            let node_id = format!("route:{path}");
+            nodes.insert(
+                node_id.clone(),
+                GraphNode {
+                    id: node_id.clone(),
+                    kind: ComponentKind::HttpRoute { path, methods },
+                },
+            );
+            edges.push(GraphEdge {
+                from: root_id.clone(),
+                to: node_id,
+                kind: EdgeKind::Contains,
+            });
+        }
+
+        for worker in self.background_workers.workers() {
+            let BackgroundWorkerDescriptor { name, queue } = worker;
+            let node_id = format!("worker:{name}");
+            nodes.insert(
+                node_id.clone(),
+                GraphNode {
+                    id: node_id.clone(),
+                    kind: ComponentKind::BackgroundWorker { name, queue },
+                },
+            );
+            edges.push(GraphEdge {
+                from: root_id.clone(),
+                to: node_id,
+                kind: EdgeKind::Contains,
+            });
+        }
+
+        let mut scheduler_edges: Vec<GraphEdge> = Vec::new();
+        for job in self.scheduler.jobs() {
+            let SchedulerJobDescriptor {
+                name,
+                schedule,
+                command,
+                run_on_start,
+                shell,
+                mut tags,
+            } = job;
+
+            let node_id = format!("scheduler:{name}");
+            tags.sort();
+            tags.dedup();
+
+            let trigger = scheduler_task_reference(&command, shell);
+
+            nodes.insert(
+                node_id.clone(),
+                GraphNode {
+                    id: node_id.clone(),
+                    kind: ComponentKind::SchedulerJob {
+                        name,
+                        schedule,
+                        command,
+                        run_on_start,
+                        shell,
+                        tags,
+                    },
+                },
+            );
+            edges.push(GraphEdge {
+                from: root_id.clone(),
+                to: node_id.clone(),
+                kind: EdgeKind::Contains,
+            });
+
+            if let Some(task_name) = trigger {
+                if let Some(task_node_id) = task_nodes.get(&task_name) {
+                    scheduler_edges.push(GraphEdge {
+                        from: node_id,
+                        to: task_node_id.clone(),
+                        kind: EdgeKind::Triggers,
+                    });
+                }
+            }
+        }
+
+        edges.extend(scheduler_edges);
+        edges.sort_by(|a, b| {
+            let a_key = (&a.from, &a.to, a.kind.sort_key());
+            let b_key = (&b.from, &b.to, b.kind.sort_key());
+            a_key.cmp(&b_key)
+        });
+        edges.dedup();
+
+        ApplicationGraph {
+            nodes: nodes.into_values().collect(),
+            edges,
+        }
+    }
+}
+
+fn scheduler_task_reference(command: &str, shell: bool) -> Option<String> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = if shell {
+        trimmed
+            .strip_prefix("task ")
+            .and_then(|rest| rest.split_whitespace().next())
+    } else {
+        trimmed.split_whitespace().next()
+    }?;
+
+    Some(candidate.to_string())
+}

--- a/src/introspection/graph/mod.rs
+++ b/src/introspection/graph/mod.rs
@@ -1,0 +1,2 @@
+pub mod domain;
+pub mod service;

--- a/src/introspection/graph/service.rs
+++ b/src/introspection/graph/service.rs
@@ -1,0 +1,243 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use crate::{
+    app::AppContext,
+    bgworker::Queue,
+    controller::{AppRoutes, ListRoutes},
+    scheduler,
+    task::Tasks,
+};
+
+use super::domain::{
+    ApplicationGraph, BackgroundWorkerDescriptor, BackgroundWorkerRepository, GraphBuilder,
+    RouteDescriptor, RoutesRepository, SchedulerJobDescriptor, SchedulerRepository, TaskDescriptor,
+    TaskRepository,
+};
+
+/// Service that adapts framework-specific data sources to the graph domain.
+pub struct ApplicationGraphService<'a> {
+    app_name: &'a str,
+    routes: Vec<ListRoutes>,
+    queue_provider: Option<Arc<Queue>>,
+    scheduler_config: Option<&'a scheduler::Config>,
+    context: &'a AppContext,
+    task_registry: Option<&'a Tasks>,
+}
+
+impl<'a> ApplicationGraphService<'a> {
+    /// Builds the service from the [`AppRoutes`] definition and application context.
+    pub fn new(app_name: &'a str, routes: &'a AppRoutes, context: &'a AppContext) -> Self {
+        Self::from_list_routes(app_name, routes.collect(), context)
+    }
+
+    /// Builds the service from already collected routes, allowing tests to stub the data.
+    pub fn from_list_routes(
+        app_name: &'a str,
+        routes: Vec<ListRoutes>,
+        context: &'a AppContext,
+    ) -> Self {
+        Self {
+            app_name,
+            routes,
+            queue_provider: context.queue_provider.clone(),
+            scheduler_config: context.config.scheduler.as_ref(),
+            context,
+            task_registry: None,
+        }
+    }
+
+    /// Overrides the queue provider dependency.
+    pub fn with_queue_provider(mut self, queue_provider: Option<Arc<Queue>>) -> Self {
+        self.queue_provider = queue_provider;
+        self
+    }
+
+    /// Overrides the scheduler configuration dependency.
+    pub fn with_scheduler_config(
+        mut self,
+        scheduler_config: Option<&'a scheduler::Config>,
+    ) -> Self {
+        self.scheduler_config = scheduler_config;
+        self
+    }
+
+    /// Overrides the task registry dependency, bypassing the shared store lookup.
+    pub fn with_task_registry(mut self, registry: Option<&'a Tasks>) -> Self {
+        self.task_registry = registry;
+        self
+    }
+
+    /// Overrides the collected routes.
+    pub fn with_routes(mut self, routes: Vec<ListRoutes>) -> Self {
+        self.routes = routes;
+        self
+    }
+
+    /// Materialises the [`ApplicationGraph`] using the domain builder.
+    pub fn build_graph(&self) -> ApplicationGraph {
+        GraphBuilder::new(self.app_name, self, self, self, self).build()
+    }
+}
+
+impl RoutesRepository for ApplicationGraphService<'_> {
+    fn routes(&self) -> Vec<RouteDescriptor> {
+        let mut aggregated: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+        for route in &self.routes {
+            let entry = aggregated.entry(route.uri.clone()).or_default();
+            for method in &route.actions {
+                entry.insert(method.to_string());
+            }
+        }
+
+        aggregated
+            .into_iter()
+            .map(|(path, methods)| RouteDescriptor {
+                path,
+                methods: methods.into_iter().collect(),
+            })
+            .collect()
+    }
+}
+
+impl BackgroundWorkerRepository for ApplicationGraphService<'_> {
+    fn workers(&self) -> Vec<BackgroundWorkerDescriptor> {
+        let mut names = BTreeSet::new();
+
+        if let Some(queue) = &self.queue_provider {
+            match queue.as_ref() {
+                #[cfg(feature = "bg_redis")]
+                Queue::Redis(_, registry, _, _) => {
+                    names.extend(read_registry_names(Arc::clone(registry)));
+                }
+                #[cfg(feature = "bg_pg")]
+                Queue::Postgres(_, registry, _, _) => {
+                    names.extend(read_registry_names(Arc::clone(registry)));
+                }
+                #[cfg(feature = "bg_sqlt")]
+                Queue::Sqlite(_, registry, _, _) => {
+                    names.extend(read_registry_names(Arc::clone(registry)));
+                }
+                Queue::None => {}
+            }
+        }
+
+        names
+            .into_iter()
+            .map(|name| BackgroundWorkerDescriptor { name, queue: None })
+            .collect()
+    }
+}
+
+impl SchedulerRepository for ApplicationGraphService<'_> {
+    fn jobs(&self) -> Vec<SchedulerJobDescriptor> {
+        let mut result = Vec::new();
+
+        if let Some(config) = self.scheduler_config {
+            let mut jobs: Vec<_> = config.jobs.iter().collect();
+            jobs.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+            for (name, job) in jobs {
+                let mut tags = job.tags.clone().unwrap_or_default();
+                tags.sort();
+                tags.dedup();
+                result.push(SchedulerJobDescriptor {
+                    name: name.clone(),
+                    schedule: job.cron.clone(),
+                    command: job.run.clone(),
+                    run_on_start: job.run_on_start,
+                    shell: job.shell,
+                    tags,
+                });
+            }
+        }
+
+        result
+    }
+}
+
+impl TaskRepository for ApplicationGraphService<'_> {
+    fn tasks(&self) -> Vec<TaskDescriptor> {
+        if let Some(registry) = self.task_registry {
+            return collect_tasks(registry);
+        }
+
+        if let Some(registry) = self.context.shared_store.get_ref::<Tasks>() {
+            return collect_tasks(&registry);
+        }
+
+        Vec::new()
+    }
+}
+
+/// Collects task descriptors from a registry and keeps the output sorted for determinism.
+fn collect_tasks(tasks: &Tasks) -> Vec<TaskDescriptor> {
+    let mut descriptors: Vec<_> = tasks
+        .list()
+        .into_iter()
+        .map(|info| TaskDescriptor {
+            name: info.name,
+            detail: Some(info.detail),
+        })
+        .collect();
+    descriptors.sort_by(|left, right| left.name.cmp(&right.name));
+    descriptors
+}
+
+#[cfg(any(feature = "bg_redis", feature = "bg_pg", feature = "bg_sqlt"))]
+fn read_registry_names<R>(registry: Arc<tokio::sync::Mutex<R>>) -> Vec<String>
+where
+    R: RegistryExtractor,
+{
+    block_on_registry(async move {
+        let guard = registry.lock().await;
+        guard.handler_names()
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(any(feature = "bg_redis", feature = "bg_pg", feature = "bg_sqlt"))]
+trait RegistryExtractor {
+    fn handler_names(&self) -> Vec<String>;
+}
+
+#[cfg(feature = "bg_redis")]
+impl RegistryExtractor for crate::bgworker::redis::JobRegistry {
+    fn handler_names(&self) -> Vec<String> {
+        self.handlers().keys().cloned().collect()
+    }
+}
+
+#[cfg(feature = "bg_pg")]
+impl RegistryExtractor for crate::bgworker::pg::JobRegistry {
+    fn handler_names(&self) -> Vec<String> {
+        self.handlers().keys().cloned().collect()
+    }
+}
+
+#[cfg(feature = "bg_sqlt")]
+impl RegistryExtractor for crate::bgworker::sqlt::JobRegistry {
+    fn handler_names(&self) -> Vec<String> {
+        self.handlers().keys().cloned().collect()
+    }
+}
+
+#[cfg(any(feature = "bg_redis", feature = "bg_pg", feature = "bg_sqlt"))]
+fn block_on_registry<F, T>(future: F) -> Option<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    use tokio::runtime::{Builder, Handle};
+
+    match Handle::try_current() {
+        Ok(handle) => Some(handle.block_on(future)),
+        Err(_) => Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .ok()
+            .map(|rt| rt.block_on(future)),
+    }
+}

--- a/src/introspection/mod.rs
+++ b/src/introspection/mod.rs
@@ -1,0 +1,1 @@
+pub mod graph;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod env_vars;
 pub mod environment;
 pub mod errors;
 pub mod hash;
+pub mod introspection;
 pub mod logger;
 pub mod mailer;
 pub mod scheduler;

--- a/tests/graph_domain.rs
+++ b/tests/graph_domain.rs
@@ -1,0 +1,179 @@
+use loco_rs::introspection::graph::domain::{
+    ApplicationGraph, BackgroundWorkerDescriptor, BackgroundWorkerRepository, ComponentKind,
+    EdgeKind, GraphBuilder, GraphEdge, GraphNode, RouteDescriptor, RoutesRepository,
+    SchedulerJobDescriptor, SchedulerRepository, TaskDescriptor, TaskRepository,
+};
+
+struct RoutesStub {
+    routes: Vec<RouteDescriptor>,
+}
+
+impl RoutesRepository for RoutesStub {
+    fn routes(&self) -> Vec<RouteDescriptor> {
+        self.routes.clone()
+    }
+}
+
+struct WorkersStub {
+    workers: Vec<BackgroundWorkerDescriptor>,
+}
+
+impl BackgroundWorkerRepository for WorkersStub {
+    fn workers(&self) -> Vec<BackgroundWorkerDescriptor> {
+        self.workers.clone()
+    }
+}
+
+struct SchedulerStub {
+    jobs: Vec<SchedulerJobDescriptor>,
+}
+
+impl SchedulerRepository for SchedulerStub {
+    fn jobs(&self) -> Vec<SchedulerJobDescriptor> {
+        self.jobs.clone()
+    }
+}
+
+struct TasksStub {
+    tasks: Vec<TaskDescriptor>,
+}
+
+impl TaskRepository for TasksStub {
+    fn tasks(&self) -> Vec<TaskDescriptor> {
+        self.tasks.clone()
+    }
+}
+
+fn find_node<'a>(
+    graph: &'a ApplicationGraph,
+    predicate: impl Fn(&'a GraphNode) -> bool,
+) -> &'a GraphNode {
+    graph
+        .nodes
+        .iter()
+        .find(|node| predicate(node))
+        .expect("expected node to exist")
+}
+
+#[test]
+fn builds_graph_with_routes_workers_jobs_and_tasks() {
+    let routes = RoutesStub {
+        routes: vec![
+            RouteDescriptor {
+                path: "/health".into(),
+                methods: vec!["GET".into()],
+            },
+            RouteDescriptor {
+                path: "/users".into(),
+                methods: vec!["GET".into(), "POST".into()],
+            },
+        ],
+    };
+
+    let workers = WorkersStub {
+        workers: vec![BackgroundWorkerDescriptor {
+            name: "ProcessEmail".into(),
+            queue: Some("default".into()),
+        }],
+    };
+
+    let scheduler = SchedulerStub {
+        jobs: vec![SchedulerJobDescriptor {
+            name: "nightly_cleanup".into(),
+            schedule: "0 0 * * *".into(),
+            command: "cleanup".into(),
+            run_on_start: false,
+            shell: false,
+            tags: vec!["maintenance".into()],
+        }],
+    };
+
+    let tasks = TasksStub {
+        tasks: vec![
+            TaskDescriptor {
+                name: "cleanup".into(),
+                detail: Some("Cleanup stale data".into()),
+            },
+            TaskDescriptor {
+                name: "send_welcome_email".into(),
+                detail: Some("Send welcome email".into()),
+            },
+        ],
+    };
+
+    let builder = GraphBuilder::new("demo-app", &routes, &workers, &scheduler, &tasks);
+
+    let graph = builder.build();
+
+    assert_eq!(graph.nodes.len(), 7);
+
+    let app_node = find_node(&graph, |node| {
+        matches!(&node.kind, ComponentKind::Application { .. })
+    });
+    assert!(matches!(&app_node.kind, ComponentKind::Application { name } if name == "demo-app"));
+
+    let route_nodes: Vec<_> = graph
+        .nodes
+        .iter()
+        .filter(|node| matches!(&node.kind, ComponentKind::HttpRoute { .. }))
+        .collect();
+    assert_eq!(route_nodes.len(), 2);
+
+    for route_node in route_nodes {
+        let edge = GraphEdge {
+            from: app_node.id.clone(),
+            to: route_node.id.clone(),
+            kind: EdgeKind::Contains,
+        };
+        assert!(
+            graph.edges.contains(&edge),
+            "missing edge from app to route"
+        );
+    }
+
+    let scheduler_node = find_node(
+        &graph,
+        |node| matches!(&node.kind, ComponentKind::SchedulerJob { name, .. } if name == "nightly_cleanup"),
+    );
+    let cleanup_task_node = find_node(
+        &graph,
+        |node| matches!(&node.kind, ComponentKind::Task { name, .. } if name == "cleanup"),
+    );
+
+    let trigger_edge = GraphEdge {
+        from: scheduler_node.id.clone(),
+        to: cleanup_task_node.id.clone(),
+        kind: EdgeKind::Triggers,
+    };
+    assert!(graph.edges.contains(&trigger_edge));
+}
+
+#[test]
+fn scheduler_job_without_matching_task_has_no_trigger_edge() {
+    let routes = RoutesStub { routes: vec![] };
+    let workers = WorkersStub { workers: vec![] };
+    let scheduler = SchedulerStub {
+        jobs: vec![SchedulerJobDescriptor {
+            name: "shell_command".into(),
+            schedule: "*/5 * * * *".into(),
+            command: "echo hello".into(),
+            run_on_start: true,
+            shell: true,
+            tags: vec![],
+        }],
+    };
+    let tasks = TasksStub { tasks: vec![] };
+
+    let graph = GraphBuilder::new("demo", &routes, &workers, &scheduler, &tasks).build();
+
+    let scheduler_node = find_node(
+        &graph,
+        |node| matches!(&node.kind, ComponentKind::SchedulerJob { name, .. } if name == "shell_command"),
+    );
+
+    assert!(graph
+        .edges
+        .iter()
+        .filter(|edge| edge.from == scheduler_node.id)
+        .all(|edge| edge.kind != EdgeKind::Triggers));
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,4 @@
 mod build_scripts;
 mod controller;
+mod graph_domain;
 mod infra_cfg;


### PR DESCRIPTION
## Summary
- add domain layer for graph introspection with value objects and repository traits
- implement an application graph service wiring AppContext resources into the domain
- add tests that describe the expected graph output from stubbed repositories

## Testing
- cargo test graph_domain

------
