### PR TITLE
Add graph introspection port with HTTP and CLI adapters

### DIFF
--- a/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]graph].snap
+++ b/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]graph].snap
@@ -1,0 +1,6 @@
+---
+source: src/controller/app_routes.rs
+assertion_line: 334
+expression: "format!(\"{:?} {}\", route.actions, route.uri)"
+---
+"[GET] /__loco/graph"

--- a/src/introspection/graph/domain.rs
+++ b/src/introspection/graph/domain.rs
@@ -1,21 +1,23 @@
 use std::collections::BTreeMap;
 
+use serde::Serialize;
+
 /// Represents the full application graph composed of nodes and edges.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ApplicationGraph {
     pub nodes: Vec<GraphNode>,
     pub edges: Vec<GraphEdge>,
 }
 
 /// Describes a vertex in the application graph.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct GraphNode {
     pub id: String,
     pub kind: ComponentKind,
 }
 
 /// Categorises the type of component represented by a [`GraphNode`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum ComponentKind {
     Application {
         name: String,
@@ -43,7 +45,7 @@ pub enum ComponentKind {
 }
 
 /// Relationship between two nodes in the application graph.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct GraphEdge {
     pub from: String,
     pub to: String,
@@ -51,7 +53,7 @@ pub struct GraphEdge {
 }
 
 /// Describes the semantics of an edge.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum EdgeKind {
     Contains,
     Triggers,
@@ -67,21 +69,21 @@ impl EdgeKind {
 }
 
 /// HTTP route description independent of the framework wiring.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RouteDescriptor {
     pub path: String,
     pub methods: Vec<String>,
 }
 
 /// Background worker description extracted from queue registries.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BackgroundWorkerDescriptor {
     pub name: String,
     pub queue: Option<String>,
 }
 
 /// Scheduler job description extracted from the scheduler configuration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SchedulerJobDescriptor {
     pub name: String,
     pub schedule: String,
@@ -92,7 +94,7 @@ pub struct SchedulerJobDescriptor {
 }
 
 /// Task description exposed by the task registry.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TaskDescriptor {
     pub name: String,
     pub detail: Option<String>,

--- a/tests/controller/graph.rs
+++ b/tests/controller/graph.rs
@@ -1,0 +1,57 @@
+use std::net::SocketAddr;
+
+use axum::{http::StatusCode, Router};
+use insta::assert_snapshot;
+use loco_rs::{
+    app::Hooks,
+    introspection::graph::service::{
+        ApplicationGraphService, GraphIntrospectionSeed, GraphQueryService,
+    },
+    TestServer,
+};
+use serde_json::Value;
+
+use loco_rs::tests_cfg;
+
+#[tokio::test]
+async fn graph_endpoint_matches_cli_snapshot() {
+    let ctx = tests_cfg::app::get_app_context().await;
+    let app_routes = tests_cfg::db::AppHook::routes(&ctx);
+    let collected_routes = app_routes.collect();
+    let route_descriptors =
+        ApplicationGraphService::collect_route_descriptors(&collected_routes);
+    ctx.shared_store.insert(GraphIntrospectionSeed::new(
+        tests_cfg::db::AppHook::app_name(),
+        route_descriptors,
+    ));
+
+    let router = app_routes
+        .to_router::<tests_cfg::db::AppHook>(ctx.clone(), Router::new())
+        .expect("build monitoring router");
+
+    let server = TestServer::new(router.into_make_service_with_connect_info::<SocketAddr>())
+        .expect("start test server");
+
+    let response = server.get("/__loco/graph").await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    let http_json: Value = response.json::<Value>();
+    assert!(http_json.get("routes").is_some());
+    assert!(http_json.get("dependencies").is_some());
+    assert_eq!(http_json["health"]["ok"], Value::Bool(true));
+
+    let cli_value = {
+        let seed = ctx
+            .shared_store
+            .get_ref::<GraphIntrospectionSeed>()
+            .expect("graph metadata should be seeded");
+        serde_json::to_value(seed.into_service(&ctx).snapshot()).unwrap()
+    };
+
+    assert_eq!(http_json, cli_value);
+    assert_snapshot!(
+        "graph_cli_snapshot",
+        serde_json::to_string_pretty(&cli_value).expect("serialize graph snapshot")
+    );
+}

--- a/tests/controller/mod.rs
+++ b/tests/controller/mod.rs
@@ -1,3 +1,4 @@
 mod extractor;
+mod graph;
 mod into_response;
 mod middlewares;

--- a/tests/controller/snapshots/r#mod__controller__graph__graph_cli_snapshot.snap
+++ b/tests/controller/snapshots/r#mod__controller__graph__graph_cli_snapshot.snap
@@ -1,0 +1,51 @@
+---
+source: tests/controller/graph.rs
+expression: "serde_json::to_string_pretty(&cli_value).expect(\"serialize graph snapshot\")"
+---
+{
+  "dependencies": {
+    "background_workers": [],
+    "scheduler_jobs": [
+      {
+        "command": "echo loco",
+        "name": "job 1",
+        "run_on_start": false,
+        "schedule": "*/5 * * * * *",
+        "shell": true,
+        "tags": [
+          "base"
+        ]
+      }
+    ],
+    "tasks": []
+  },
+  "health": {
+    "ok": true
+  },
+  "routes": [
+    {
+      "methods": [
+        "GET"
+      ],
+      "path": "/__loco/graph"
+    },
+    {
+      "methods": [
+        "GET"
+      ],
+      "path": "/_health"
+    },
+    {
+      "methods": [
+        "GET"
+      ],
+      "path": "/_ping"
+    },
+    {
+      "methods": [
+        "GET"
+      ],
+      "path": "/_readiness"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- introduce a GraphQueryService port that materializes reusable graph snapshots and cache the required metadata when booting routes
- expose a `/__loco/graph` monitoring endpoint backed by the graph service and wire a new `cargo loco doctor --graph` mode
- add integration coverage that compares the HTTP output with the CLI snapshot and update default route snapshots

## Testing
- `cargo test controller::app_routes::tests::can_load_app_route_from_default --lib`
- `cargo test graph_endpoint_matches_cli_snapshot --test mod`
- `cargo test` *(fails: local environment lacks Docker/Redis for bgworker/database suites)*

------
