### PR TITLE
Add ontology domain core and contracts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ serde_variant = "0.1.2"
 toml = "0.8"
 
 async-trait = { workspace = true }
+oxrdf = "0.3.0"
 
 axum = { workspace = true }
 axum-extra = { version = "0.10", features = ["cookie"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod hash;
 pub mod introspection;
 pub mod logger;
 pub mod mailer;
+pub mod ontology;
 pub mod scheduler;
 pub mod task;
 #[cfg(feature = "testing")]

--- a/src/ontology/entities.rs
+++ b/src/ontology/entities.rs
@@ -1,0 +1,491 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+
+use super::value_objects::Iri;
+
+/// Ontology class definition capturing parent relationships and metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Class {
+    id: Iri,
+    label: Option<String>,
+    comment: Option<String>,
+    super_classes: BTreeSet<Iri>,
+}
+
+impl Class {
+    /// Creates a new [`Class`] with the supplied identifier.
+    #[must_use]
+    pub fn new(id: Iri) -> Self {
+        Self {
+            id,
+            label: None,
+            comment: None,
+            super_classes: BTreeSet::new(),
+        }
+    }
+
+    /// Sets a human friendly label for the class.
+    #[must_use]
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Sets a textual description for the class.
+    #[must_use]
+    pub fn with_comment(mut self, comment: impl Into<String>) -> Self {
+        self.comment = Some(comment.into());
+        self
+    }
+
+    /// Adds a new parent class relation.
+    pub fn add_parent(&mut self, parent: Iri) -> bool {
+        self.super_classes.insert(parent)
+    }
+
+    /// Removes a parent class relation.
+    pub fn remove_parent(&mut self, parent: &Iri) -> bool {
+        self.super_classes.remove(parent)
+    }
+
+    /// Returns the unique identifier of the class.
+    #[must_use]
+    pub fn id(&self) -> &Iri {
+        &self.id
+    }
+
+    /// Returns the optional label.
+    #[must_use]
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Returns the optional comment.
+    #[must_use]
+    pub fn comment(&self) -> Option<&str> {
+        self.comment.as_deref()
+    }
+
+    /// Returns the parent classes in lexical order.
+    #[must_use]
+    pub fn parents(&self) -> &BTreeSet<Iri> {
+        &self.super_classes
+    }
+}
+
+/// Ontology property definition supporting object and data properties.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Property {
+    id: Iri,
+    label: Option<String>,
+    kind: PropertyKind,
+    domains: BTreeSet<Iri>,
+    ranges: BTreeSet<Iri>,
+}
+
+impl Property {
+    /// Creates a new property with the provided identifier and kind.
+    #[must_use]
+    pub fn new(id: Iri, kind: PropertyKind) -> Self {
+        Self {
+            id,
+            label: None,
+            kind,
+            domains: BTreeSet::new(),
+            ranges: BTreeSet::new(),
+        }
+    }
+
+    /// Sets a human readable label for the property.
+    #[must_use]
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Declares that the property applies to the supplied domain class.
+    pub fn add_domain(&mut self, class: Iri) -> bool {
+        self.domains.insert(class)
+    }
+
+    /// Declares that the property produces values from the supplied range class.
+    pub fn add_range(&mut self, class: Iri) -> bool {
+        self.ranges.insert(class)
+    }
+
+    /// Returns the property identifier.
+    #[must_use]
+    pub fn id(&self) -> &Iri {
+        &self.id
+    }
+
+    /// Returns the optional label.
+    #[must_use]
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Returns the property kind.
+    #[must_use]
+    pub fn kind(&self) -> PropertyKind {
+        self.kind
+    }
+
+    /// Returns the registered domain classes.
+    #[must_use]
+    pub fn domains(&self) -> &BTreeSet<Iri> {
+        &self.domains
+    }
+
+    /// Returns the registered range classes.
+    #[must_use]
+    pub fn ranges(&self) -> &BTreeSet<Iri> {
+        &self.ranges
+    }
+}
+
+/// Classifies the type of values a property can hold.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PropertyKind {
+    /// Object properties link individuals.
+    Object,
+    /// Data properties capture literal values.
+    Data,
+}
+
+/// Property assertions attached to individuals.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PropertyAssertion {
+    /// Object properties target another individual.
+    Individual(Iri),
+    /// Data properties store literal values.
+    Literal(String),
+}
+
+/// An ontology individual containing class memberships and property assertions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Individual {
+    id: Iri,
+    types: BTreeSet<Iri>,
+    properties: BTreeMap<Iri, Vec<PropertyAssertion>>,
+}
+
+impl Individual {
+    /// Creates a new individual with the supplied identifier.
+    #[must_use]
+    pub fn new(id: Iri) -> Self {
+        Self {
+            id,
+            types: BTreeSet::new(),
+            properties: BTreeMap::new(),
+        }
+    }
+
+    /// Declares that the individual is an instance of the given class.
+    pub fn assert_type(&mut self, class: Iri) -> bool {
+        self.types.insert(class)
+    }
+
+    /// Associates the individual with a property assertion.
+    pub fn add_property_assertion(&mut self, property: Iri, assertion: PropertyAssertion) {
+        self.properties
+            .entry(property)
+            .or_insert_with(Vec::new)
+            .push(assertion);
+    }
+
+    /// Returns the identifier of the individual.
+    #[must_use]
+    pub fn id(&self) -> &Iri {
+        &self.id
+    }
+
+    /// Returns the declared types.
+    #[must_use]
+    pub fn types(&self) -> &BTreeSet<Iri> {
+        &self.types
+    }
+
+    /// Returns the property assertions.
+    #[must_use]
+    pub fn properties(&self) -> &BTreeMap<Iri, Vec<PropertyAssertion>> {
+        &self.properties
+    }
+}
+
+/// Aggregates ontology classes, properties and individuals.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Ontology {
+    id: Iri,
+    label: Option<String>,
+    classes: BTreeMap<Iri, Class>,
+    properties: BTreeMap<Iri, Property>,
+    individuals: BTreeMap<Iri, Individual>,
+}
+
+impl Ontology {
+    /// Creates a new ontology aggregate with the supplied identifier.
+    #[must_use]
+    pub fn new(id: Iri) -> Self {
+        Self {
+            id,
+            label: None,
+            classes: BTreeMap::new(),
+            properties: BTreeMap::new(),
+            individuals: BTreeMap::new(),
+        }
+    }
+
+    /// Sets a human readable label for the ontology.
+    #[must_use]
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Adds a class to the ontology, enforcing unique identifiers.
+    pub fn add_class(&mut self, class: Class) -> Result<(), OntologyError> {
+        let id = class.id().clone();
+        if self.classes.contains_key(&id) {
+            return Err(OntologyError::DuplicateClass(id));
+        }
+        self.classes.insert(id, class);
+        Ok(())
+    }
+
+    /// Adds a property to the ontology, validating references to known classes.
+    pub fn add_property(&mut self, property: Property) -> Result<(), OntologyError> {
+        let id = property.id().clone();
+        if self.properties.contains_key(&id) {
+            return Err(OntologyError::DuplicateProperty(id));
+        }
+
+        for class in property.domains() {
+            if !self.classes.contains_key(class) {
+                return Err(OntologyError::MissingClass {
+                    ontology: self.id.clone(),
+                    class: class.clone(),
+                });
+            }
+        }
+        for class in property.ranges() {
+            if !self.classes.contains_key(class) {
+                return Err(OntologyError::MissingClass {
+                    ontology: self.id.clone(),
+                    class: class.clone(),
+                });
+            }
+        }
+
+        self.properties.insert(id, property);
+        Ok(())
+    }
+
+    /// Adds an individual ensuring it references known classes and properties.
+    pub fn add_individual(&mut self, individual: Individual) -> Result<(), OntologyError> {
+        let id = individual.id().clone();
+        if self.individuals.contains_key(&id) {
+            return Err(OntologyError::DuplicateIndividual(id));
+        }
+
+        for class in individual.types() {
+            if !self.classes.contains_key(class) {
+                return Err(OntologyError::MissingClass {
+                    ontology: self.id.clone(),
+                    class: class.clone(),
+                });
+            }
+        }
+
+        for (property_id, assertions) in individual.properties() {
+            let Some(property) = self.properties.get(property_id) else {
+                return Err(OntologyError::MissingProperty {
+                    ontology: self.id.clone(),
+                    property: property_id.clone(),
+                });
+            };
+
+            for assertion in assertions {
+                match (property.kind(), assertion) {
+                    (PropertyKind::Object, PropertyAssertion::Individual(_)) => {}
+                    (PropertyKind::Data, PropertyAssertion::Literal(_)) => {}
+                    _ => {
+                        return Err(OntologyError::InvalidPropertyAssertion {
+                            ontology: self.id.clone(),
+                            property: property_id.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        self.individuals.insert(id, individual);
+        Ok(())
+    }
+
+    /// Returns the ontology identifier.
+    #[must_use]
+    pub fn id(&self) -> &Iri {
+        &self.id
+    }
+
+    /// Returns the optional label.
+    #[must_use]
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Retrieves a class by identifier.
+    #[must_use]
+    pub fn class(&self, id: &Iri) -> Option<&Class> {
+        self.classes.get(id)
+    }
+
+    /// Retrieves a property by identifier.
+    #[must_use]
+    pub fn property(&self, id: &Iri) -> Option<&Property> {
+        self.properties.get(id)
+    }
+
+    /// Retrieves an individual by identifier.
+    #[must_use]
+    pub fn individual(&self, id: &Iri) -> Option<&Individual> {
+        self.individuals.get(id)
+    }
+
+    /// Returns all classes ordered by identifier.
+    #[must_use]
+    pub fn classes(&self) -> &BTreeMap<Iri, Class> {
+        &self.classes
+    }
+
+    /// Returns all properties ordered by identifier.
+    #[must_use]
+    pub fn properties(&self) -> &BTreeMap<Iri, Property> {
+        &self.properties
+    }
+
+    /// Returns all individuals ordered by identifier.
+    #[must_use]
+    pub fn individuals(&self) -> &BTreeMap<Iri, Individual> {
+        &self.individuals
+    }
+}
+
+/// Errors raised when manipulating an ontology aggregate.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum OntologyError {
+    /// Attempted to add a class with an existing identifier.
+    #[error("class `{0}` already exists")]
+    DuplicateClass(Iri),
+    /// Attempted to add a property with an existing identifier.
+    #[error("property `{0}` already exists")]
+    DuplicateProperty(Iri),
+    /// Attempted to add an individual with an existing identifier.
+    #[error("individual `{0}` already exists")]
+    DuplicateIndividual(Iri),
+    /// Referenced class was not part of the ontology.
+    #[error("class `{class}` does not exist in ontology `{ontology}`")]
+    MissingClass { ontology: Iri, class: Iri },
+    /// Referenced property was not part of the ontology.
+    #[error("property `{property}` does not exist in ontology `{ontology}`")]
+    MissingProperty { ontology: Iri, property: Iri },
+    /// Property assertion type did not match the property definition.
+    #[error("property assertion does not match property `{property}` in ontology `{ontology}`")]
+    InvalidPropertyAssertion { ontology: Iri, property: Iri },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Class, Individual, Ontology, Property, PropertyAssertion, PropertyKind};
+    use crate::ontology::value_objects::Iri;
+
+    fn iri(text: &str) -> Iri {
+        Iri::new(text).expect("valid iri")
+    }
+
+    #[test]
+    fn class_parents_are_tracked() {
+        let mut class = Class::new(iri("https://example.org/Class"))
+            .with_label("Example")
+            .with_comment("Demo");
+        assert_eq!(class.label(), Some("Example"));
+        assert_eq!(class.comment(), Some("Demo"));
+        assert!(class.add_parent(iri("https://example.org/Base")));
+        assert!(class.parents().contains(&iri("https://example.org/Base")));
+        assert!(class.remove_parent(&iri("https://example.org/Base")));
+        assert!(class.parents().is_empty());
+    }
+
+    #[test]
+    fn property_definitions_require_known_classes() {
+        let mut ontology = Ontology::new(iri("https://example.org/onto"));
+        let class = Class::new(iri("https://example.org/Class"));
+        ontology.add_class(class).expect("class inserted");
+
+        let mut property = Property::new(iri("https://example.org/prop"), PropertyKind::Object);
+        property.add_domain(iri("https://example.org/Class"));
+        property.add_range(iri("https://example.org/Class"));
+        ontology
+            .add_property(property.clone())
+            .expect("property inserted");
+        assert_eq!(ontology.property(property.id()), Some(&property));
+    }
+
+    #[test]
+    fn property_insertion_rejects_unknown_classes() {
+        let mut ontology = Ontology::new(iri("https://example.org/onto"));
+        let mut property = Property::new(iri("https://example.org/prop"), PropertyKind::Object);
+        property.add_domain(iri("https://example.org/Class"));
+        let err = ontology.add_property(property).expect_err("missing class");
+        assert!(matches!(err, super::OntologyError::MissingClass { .. }));
+    }
+
+    #[test]
+    fn individual_insertion_checks_references() {
+        let mut ontology = Ontology::new(iri("https://example.org/onto"));
+        let class = Class::new(iri("https://example.org/Class"));
+        ontology.add_class(class).expect("class inserted");
+        let mut property = Property::new(iri("https://example.org/prop"), PropertyKind::Object);
+        property.add_domain(iri("https://example.org/Class"));
+        property.add_range(iri("https://example.org/Class"));
+        ontology.add_property(property).expect("property inserted");
+
+        let mut individual = Individual::new(iri("https://example.org/alice"));
+        individual.assert_type(iri("https://example.org/Class"));
+        individual.add_property_assertion(
+            iri("https://example.org/prop"),
+            PropertyAssertion::Individual(iri("https://example.org/bob")),
+        );
+
+        ontology
+            .add_individual(individual)
+            .expect("individual inserted");
+    }
+
+    #[test]
+    fn individual_insertion_rejects_mismatched_property_kind() {
+        let mut ontology = Ontology::new(iri("https://example.org/onto"));
+        let class = Class::new(iri("https://example.org/Class"));
+        ontology.add_class(class).expect("class inserted");
+        let mut property = Property::new(iri("https://example.org/prop"), PropertyKind::Data);
+        property.add_domain(iri("https://example.org/Class"));
+        ontology.add_property(property).expect("property inserted");
+
+        let mut individual = Individual::new(iri("https://example.org/alice"));
+        individual.assert_type(iri("https://example.org/Class"));
+        individual.add_property_assertion(
+            iri("https://example.org/prop"),
+            PropertyAssertion::Individual(iri("https://example.org/bob")),
+        );
+
+        let err = ontology
+            .add_individual(individual)
+            .expect_err("mismatched property kind");
+        assert!(matches!(
+            err,
+            super::OntologyError::InvalidPropertyAssertion { .. }
+        ));
+    }
+}

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -1,0 +1,16 @@
+//! Core ontology domain primitives and contracts.
+//!
+//! The module defines rich value objects and aggregate roots describing ontologies
+//! independently from persistence or transport concerns. It embraces a hexagonal
+//! architecture approach by keeping only pure domain constructs and traits that
+//! describe the required infrastructure behavior.
+
+pub mod entities;
+pub mod repositories;
+pub mod value_objects;
+
+pub use entities::{
+    Class, Individual, Ontology, OntologyError, Property, PropertyAssertion, PropertyKind,
+};
+pub use repositories::{OntologyRepository, OntologySnapshot, OntologySummary, ReasoningQuery};
+pub use value_objects::{Iri, IriError};

--- a/src/ontology/repositories.rs
+++ b/src/ontology/repositories.rs
@@ -1,0 +1,482 @@
+use async_trait::async_trait;
+
+use super::entities::{Class, Individual, Ontology, Property};
+use super::value_objects::Iri;
+
+/// Lightweight snapshot returned by repository lookups.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OntologySnapshot {
+    /// Full ontology aggregate.
+    pub ontology: Ontology,
+}
+
+impl From<Ontology> for OntologySnapshot {
+    fn from(ontology: Ontology) -> Self {
+        Self { ontology }
+    }
+}
+
+/// Summary DTO for listing ontologies without loading the full aggregate.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OntologySummary {
+    /// Identifier of the ontology.
+    pub iri: Iri,
+    /// Optional label for display purposes.
+    pub label: Option<String>,
+    /// Number of class declarations.
+    pub class_count: usize,
+    /// Number of property declarations.
+    pub property_count: usize,
+    /// Number of individuals.
+    pub individual_count: usize,
+}
+
+impl From<&Ontology> for OntologySummary {
+    fn from(ontology: &Ontology) -> Self {
+        Self {
+            iri: ontology.id().clone(),
+            label: ontology.label().map(|label| label.to_string()),
+            class_count: ontology.classes().len(),
+            property_count: ontology.properties().len(),
+            individual_count: ontology.individuals().len(),
+        }
+    }
+}
+
+/// Contract describing persistence responsibilities for ontology aggregates.
+#[async_trait]
+pub trait OntologyRepository {
+    /// Associated error type allowing infrastructure specific failures.
+    type Error;
+
+    /// Persists a brand new ontology.
+    ///
+    /// Implementors are expected to reject duplicate IRIs and to persist the
+    /// ontology atomically.
+    async fn insert(&self, ontology: Ontology) -> Result<(), Self::Error>;
+
+    /// Updates an existing ontology aggregate.
+    ///
+    /// Implementors should replace the stored aggregate while ensuring
+    /// concurrent updates are properly serialized.
+    async fn update(&self, ontology: Ontology) -> Result<(), Self::Error>;
+
+    /// Retrieves a stored ontology by identifier.
+    ///
+    /// Implementors must return `Ok(None)` when the ontology is missing.
+    async fn get(&self, iri: &Iri) -> Result<Option<OntologySnapshot>, Self::Error>;
+
+    /// Deletes an ontology and all nested resources.
+    async fn delete(&self, iri: &Iri) -> Result<(), Self::Error>;
+
+    /// Lists all ontologies without loading the entire aggregate.
+    async fn list(&self) -> Result<Vec<OntologySummary>, Self::Error>;
+
+    /// Appends a class declaration to an existing ontology.
+    ///
+    /// The provided [`Class`] should be validated using the domain aggregate to
+    /// guarantee referential integrity.
+    async fn attach_class(&self, ontology: &Iri, class: Class) -> Result<(), Self::Error>;
+
+    /// Appends a property declaration to an existing ontology.
+    async fn attach_property(&self, ontology: &Iri, property: Property) -> Result<(), Self::Error>;
+
+    /// Appends an individual declaration to an existing ontology.
+    async fn attach_individual(
+        &self,
+        ontology: &Iri,
+        individual: Individual,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Abstraction describing reasoning and traversal operations on ontology graphs.
+#[async_trait]
+pub trait ReasoningQuery {
+    /// Associated error type allowing infrastructure specific failures.
+    type Error;
+
+    /// Returns the transitive closure of all parent classes for a given class.
+    async fn ancestors_of(&self, ontology: &Iri, class: &Iri) -> Result<Vec<Iri>, Self::Error>;
+
+    /// Returns the transitive closure of all child classes for a given class.
+    async fn descendants_of(&self, ontology: &Iri, class: &Iri) -> Result<Vec<Iri>, Self::Error>;
+
+    /// Returns individuals connected to the supplied source via the provided property.
+    async fn related_individuals(
+        &self,
+        ontology: &Iri,
+        via_property: &Iri,
+        individual: &Iri,
+    ) -> Result<Vec<Iri>, Self::Error>;
+
+    /// Returns the shortest property path between two individuals, if one exists.
+    async fn shortest_path(
+        &self,
+        ontology: &Iri,
+        start: &Iri,
+        end: &Iri,
+    ) -> Result<Option<Vec<Iri>>, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OntologyRepository, OntologySnapshot, OntologySummary, ReasoningQuery};
+    use crate::ontology::entities::{
+        Class, Individual, Ontology, Property, PropertyAssertion, PropertyKind,
+    };
+    use crate::ontology::value_objects::Iri;
+    use async_trait::async_trait;
+    use std::collections::{BTreeMap, BTreeSet, VecDeque};
+    use std::sync::Mutex;
+
+    fn iri(text: &str) -> Iri {
+        Iri::new(text).expect("valid iri")
+    }
+
+    #[derive(Default)]
+    struct InMemoryOntologyRepository {
+        store: Mutex<BTreeMap<Iri, Ontology>>,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    enum TestError {
+        #[error("ontology already exists")]
+        Duplicate,
+        #[error("ontology missing")]
+        Missing,
+        #[error("domain error: {0}")]
+        Domain(String),
+    }
+
+    #[async_trait]
+    impl OntologyRepository for InMemoryOntologyRepository {
+        type Error = TestError;
+
+        async fn insert(&self, ontology: Ontology) -> Result<(), Self::Error> {
+            let mut guard = self.store.lock().unwrap();
+            let id = ontology.id().clone();
+            if guard.contains_key(&id) {
+                return Err(TestError::Duplicate);
+            }
+            guard.insert(id, ontology);
+            Ok(())
+        }
+
+        async fn update(&self, ontology: Ontology) -> Result<(), Self::Error> {
+            let mut guard = self.store.lock().unwrap();
+            let id = ontology.id().clone();
+            if !guard.contains_key(&id) {
+                return Err(TestError::Missing);
+            }
+            guard.insert(id, ontology);
+            Ok(())
+        }
+
+        async fn get(&self, iri: &Iri) -> Result<Option<OntologySnapshot>, Self::Error> {
+            let guard = self.store.lock().unwrap();
+            Ok(guard
+                .get(iri)
+                .cloned()
+                .map(|ontology| OntologySnapshot { ontology }))
+        }
+
+        async fn delete(&self, iri: &Iri) -> Result<(), Self::Error> {
+            let mut guard = self.store.lock().unwrap();
+            guard
+                .remove(iri)
+                .map_or(Err(TestError::Missing), |_| Ok(()))
+        }
+
+        async fn list(&self) -> Result<Vec<OntologySummary>, Self::Error> {
+            let guard = self.store.lock().unwrap();
+            Ok(guard.values().map(OntologySummary::from).collect())
+        }
+
+        async fn attach_class(&self, ontology: &Iri, class: Class) -> Result<(), Self::Error> {
+            let mut guard = self.store.lock().unwrap();
+            let Some(existing) = guard.get_mut(ontology) else {
+                return Err(TestError::Missing);
+            };
+            existing
+                .add_class(class)
+                .map_err(|err| TestError::Domain(err.to_string()))
+        }
+
+        async fn attach_property(
+            &self,
+            ontology: &Iri,
+            property: Property,
+        ) -> Result<(), Self::Error> {
+            let mut guard = self.store.lock().unwrap();
+            let Some(existing) = guard.get_mut(ontology) else {
+                return Err(TestError::Missing);
+            };
+            existing
+                .add_property(property)
+                .map_err(|err| TestError::Domain(err.to_string()))
+        }
+
+        async fn attach_individual(
+            &self,
+            ontology: &Iri,
+            individual: Individual,
+        ) -> Result<(), Self::Error> {
+            let mut guard = self.store.lock().unwrap();
+            let Some(existing) = guard.get_mut(ontology) else {
+                return Err(TestError::Missing);
+            };
+            existing
+                .add_individual(individual)
+                .map_err(|err| TestError::Domain(err.to_string()))
+        }
+    }
+
+    #[async_trait]
+    impl ReasoningQuery for InMemoryOntologyRepository {
+        type Error = TestError;
+
+        async fn ancestors_of(&self, ontology: &Iri, class: &Iri) -> Result<Vec<Iri>, Self::Error> {
+            let guard = self.store.lock().unwrap();
+            let ontology = guard.get(ontology).ok_or(TestError::Missing)?;
+            let start = ontology
+                .class(class)
+                .ok_or(TestError::Domain(format!("class {class} missing")))?;
+            let mut visited = BTreeSet::new();
+            let mut queue: VecDeque<Iri> = start.parents().iter().cloned().collect();
+            while let Some(current) = queue.pop_front() {
+                if visited.insert(current.clone()) {
+                    if let Some(parent) = ontology.class(&current) {
+                        queue.extend(parent.parents().iter().cloned());
+                    }
+                }
+            }
+            Ok(visited.into_iter().collect())
+        }
+
+        async fn descendants_of(
+            &self,
+            ontology: &Iri,
+            class: &Iri,
+        ) -> Result<Vec<Iri>, Self::Error> {
+            let guard = self.store.lock().unwrap();
+            let ontology = guard.get(ontology).ok_or(TestError::Missing)?;
+            if ontology.class(class).is_none() {
+                return Err(TestError::Domain(format!("class {class} missing")));
+            }
+            let mut visited = BTreeSet::new();
+            let mut queue: VecDeque<Iri> = VecDeque::from([class.clone()]);
+            while let Some(current) = queue.pop_front() {
+                for (id, candidate) in ontology.classes() {
+                    if candidate.parents().contains(&current) && visited.insert(id.clone()) {
+                        queue.push_back(id.clone());
+                    }
+                }
+            }
+            Ok(visited.into_iter().collect())
+        }
+
+        async fn related_individuals(
+            &self,
+            ontology: &Iri,
+            via_property: &Iri,
+            individual: &Iri,
+        ) -> Result<Vec<Iri>, Self::Error> {
+            let guard = self.store.lock().unwrap();
+            let ontology = guard.get(ontology).ok_or(TestError::Missing)?;
+            let source = ontology
+                .individual(individual)
+                .ok_or_else(|| TestError::Domain(format!("individual {individual} missing")))?;
+            let Some(property) = ontology.property(via_property) else {
+                return Err(TestError::Domain(format!(
+                    "property {via_property} missing"
+                )));
+            };
+            if property.kind() != PropertyKind::Object {
+                return Err(TestError::Domain(format!(
+                    "property {via_property} is not an object property"
+                )));
+            }
+            let mut results = BTreeSet::new();
+            if let Some(assertions) = source.properties().get(via_property) {
+                for assertion in assertions {
+                    if let PropertyAssertion::Individual(target) = assertion {
+                        results.insert(target.clone());
+                    }
+                }
+            }
+            Ok(results.into_iter().collect())
+        }
+
+        async fn shortest_path(
+            &self,
+            ontology: &Iri,
+            start: &Iri,
+            end: &Iri,
+        ) -> Result<Option<Vec<Iri>>, Self::Error> {
+            let guard = self.store.lock().unwrap();
+            let ontology = guard.get(ontology).ok_or(TestError::Missing)?;
+            let Some(_) = ontology.individual(start) else {
+                return Err(TestError::Domain(format!("individual {start} missing")));
+            };
+            let Some(_) = ontology.individual(end) else {
+                return Err(TestError::Domain(format!("individual {end} missing")));
+            };
+
+            let mut queue = VecDeque::from([(start.clone(), vec![start.clone()])]);
+            let mut visited = BTreeSet::from([start.clone()]);
+            while let Some((current, path)) = queue.pop_front() {
+                if current == *end {
+                    return Ok(Some(path));
+                }
+                if let Some(individual) = ontology.individual(&current) {
+                    for (property_id, assertions) in individual.properties() {
+                        let Some(property) = ontology.property(property_id) else {
+                            continue;
+                        };
+                        if property.kind() != PropertyKind::Object {
+                            continue;
+                        }
+                        for assertion in assertions {
+                            if let PropertyAssertion::Individual(target) = assertion {
+                                if visited.insert(target.clone()) {
+                                    let mut next_path = path.clone();
+                                    next_path.push(target.clone());
+                                    queue.push_back((target.clone(), next_path));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn repository_crud_roundtrip() {
+        let repo = InMemoryOntologyRepository::default();
+        let mut ontology = Ontology::new(iri("https://example.org/onto"));
+        repo.insert(ontology.clone()).await.expect("insert");
+
+        ontology = ontology.with_label("Example");
+        repo.update(ontology.clone()).await.expect("update");
+
+        let fetched = repo
+            .get(ontology.id())
+            .await
+            .expect("get")
+            .expect("ontology exists");
+        assert_eq!(fetched.ontology.label(), Some("Example"));
+
+        let summaries = repo.list().await.expect("list");
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].label.as_deref(), Some("Example"));
+
+        repo.delete(ontology.id()).await.expect("delete");
+        assert!(repo.get(ontology.id()).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn repository_maintains_domain_invariants() {
+        let repo = InMemoryOntologyRepository::default();
+        let ontology = Ontology::new(iri("https://example.org/onto"));
+        repo.insert(ontology.clone()).await.expect("insert");
+
+        let class = Class::new(iri("https://example.org/Class"));
+        repo.attach_class(ontology.id(), class)
+            .await
+            .expect("class");
+
+        let mut property = Property::new(iri("https://example.org/prop"), PropertyKind::Object);
+        property.add_domain(iri("https://example.org/Class"));
+        property.add_range(iri("https://example.org/Class"));
+        repo.attach_property(ontology.id(), property)
+            .await
+            .expect("property");
+
+        let mut individual = Individual::new(iri("https://example.org/alice"));
+        individual.assert_type(iri("https://example.org/Class"));
+        individual.add_property_assertion(
+            iri("https://example.org/prop"),
+            PropertyAssertion::Individual(iri("https://example.org/bob")),
+        );
+        repo.attach_individual(ontology.id(), individual)
+            .await
+            .expect("individual");
+
+        let updated = repo.get(ontology.id()).await.expect("get").expect("exists");
+        assert_eq!(updated.ontology.individuals().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reasoning_operations_traverse_graphs() {
+        let repo = InMemoryOntologyRepository::default();
+        let mut ontology = Ontology::new(iri("https://example.org/onto"));
+        let base = Class::new(iri("https://example.org/Base"));
+        let mut derived = Class::new(iri("https://example.org/Derived"));
+        derived.add_parent(base.id().clone());
+        ontology.add_class(base.clone()).expect("base");
+        ontology.add_class(derived.clone()).expect("derived");
+
+        let mut link = Property::new(iri("https://example.org/link"), PropertyKind::Object);
+        link.add_domain(base.id().clone());
+        link.add_range(base.id().clone());
+        ontology.add_property(link).expect("link");
+
+        let mut alice = Individual::new(iri("https://example.org/alice"));
+        alice.assert_type(base.id().clone());
+        alice.add_property_assertion(
+            iri("https://example.org/link"),
+            PropertyAssertion::Individual(iri("https://example.org/bob")),
+        );
+        ontology.add_individual(alice).expect("alice");
+
+        let mut bob = Individual::new(iri("https://example.org/bob"));
+        bob.assert_type(base.id().clone());
+        ontology.add_individual(bob).expect("bob");
+
+        repo.insert(ontology).await.expect("insert");
+
+        let invalid_ontology = iri("https://example.org/invalid");
+        let ancestors = repo.ancestors_of(&invalid_ontology, derived.id()).await;
+        assert!(ancestors.is_err(), "invalid ontology iri should error");
+
+        let ancestors = repo
+            .ancestors_of(&iri("https://example.org/onto"), derived.id())
+            .await
+            .expect("ancestors");
+        assert_eq!(ancestors, vec![base.id().clone()]);
+
+        let descendants = repo
+            .descendants_of(&iri("https://example.org/onto"), base.id())
+            .await
+            .expect("descendants");
+        assert_eq!(descendants, vec![derived.id().clone()]);
+
+        let related = repo
+            .related_individuals(
+                &iri("https://example.org/onto"),
+                &iri("https://example.org/link"),
+                &iri("https://example.org/alice"),
+            )
+            .await
+            .expect("related");
+        assert_eq!(related, vec![iri("https://example.org/bob")]);
+
+        let path = repo
+            .shortest_path(
+                &iri("https://example.org/onto"),
+                &iri("https://example.org/alice"),
+                &iri("https://example.org/bob"),
+            )
+            .await
+            .expect("path");
+        assert_eq!(
+            path,
+            Some(vec![
+                iri("https://example.org/alice"),
+                iri("https://example.org/bob"),
+            ])
+        );
+    }
+}

--- a/src/ontology/value_objects.rs
+++ b/src/ontology/value_objects.rs
@@ -1,0 +1,78 @@
+use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
+
+use oxrdf::NamedNode;
+use thiserror::Error;
+
+/// Value object ensuring that supplied text represents a valid IRI.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Iri {
+    value: String,
+}
+
+impl Iri {
+    /// Validates and constructs a new [`Iri`] value object.
+    ///
+    /// The constructor rejects malformed identifiers in order to guarantee that
+    /// every entity uses canonical identifiers.
+    pub fn new(value: impl Into<String>) -> Result<Self, IriError> {
+        let value = value.into();
+        NamedNode::new(value.as_str()).map_err(|_| IriError::Invalid {
+            value: value.clone(),
+        })?;
+        Ok(Self { value })
+    }
+
+    /// Returns the underlying textual representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+}
+
+impl Display for Iri {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.value)
+    }
+}
+
+impl FromStr for Iri {
+    type Err = IriError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s.to_owned())
+    }
+}
+
+impl TryFrom<String> for Iri {
+    type Error = IriError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Errors produced when validating an [`Iri`].
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum IriError {
+    /// The provided text could not be parsed as an IRI.
+    #[error("invalid IRI: {value}")]
+    Invalid { value: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Iri;
+
+    #[test]
+    fn accepts_valid_iri() {
+        let iri = Iri::new("https://example.org/resource").expect("valid IRI");
+        assert_eq!(iri.as_str(), "https://example.org/resource");
+    }
+
+    #[test]
+    fn rejects_invalid_iri() {
+        let err = Iri::new("not an iri").expect_err("invalid IRI");
+        assert!(matches!(err, super::IriError::Invalid { value } if value == "not an iri"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a pure `ontology` domain module with IRIs, entities, and aggregates that enforce referential integrity
- define repository and reasoning traits with in-memory contract tests to document expected behaviors
- expose the new module and pull in `oxrdf` for IRI validation

## Testing
- `cargo test ontology::`
- `cargo test` *(fails: Docker-based Postgres/Redis integration tests cannot start `/var/run/docker.sock`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9fa028a608333b5db75c2616e6465