### PR TITLE
Add knowledge assistant abstraction and OpenAI adapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ scraper = { version = "0.21.0", features = ["deterministic"], optional = true }
 
 dashmap = "6"
 notify = "8.1.0"
+async-openai = { version = "0.23.3", default-features = false, features = ["rustls"] }
 
 [workspace.dependencies]
 tera = { version = "1.19.1" }

--- a/src/ai/infrastructure/mod.rs
+++ b/src/ai/infrastructure/mod.rs
@@ -1,0 +1,3 @@
+pub mod openai;
+
+pub use openai::OpenAiKnowledgeAssistant;

--- a/src/ai/infrastructure/openai.rs
+++ b/src/ai/infrastructure/openai.rs
@@ -1,0 +1,121 @@
+use async_openai::{
+    config::OpenAIConfig,
+    types::{
+        ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
+        ChatCompletionRequestUserMessageArgs, ChatCompletionRequestUserMessageContent,
+        CreateChatCompletionRequestArgs,
+    },
+    Client,
+};
+use async_trait::async_trait;
+
+use crate::{
+    ai::{
+        KnowledgeAssistant, KnowledgeAssistantError, KnowledgeAssistantInitError, KnowledgeRequest,
+        KnowledgeResponse,
+    },
+    config::OpenAiSettings,
+};
+
+/// Knowledge assistant backed by OpenAI chat completions.
+pub struct OpenAiKnowledgeAssistant {
+    client: Client<OpenAIConfig>,
+    model: String,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    system_prompt: Option<String>,
+}
+
+impl OpenAiKnowledgeAssistant {
+    /// Instantiates a new assistant using the provided configuration.
+    pub fn try_new(settings: &OpenAiSettings) -> Result<Self, KnowledgeAssistantInitError> {
+        if settings.api_key.trim().is_empty() {
+            return Err(KnowledgeAssistantInitError::InvalidConfiguration(
+                "`ai.assistant.api_key` must be provided".to_string(),
+            ));
+        }
+        if settings.model.trim().is_empty() {
+            return Err(KnowledgeAssistantInitError::InvalidConfiguration(
+                "`ai.assistant.model` must be provided".to_string(),
+            ));
+        }
+
+        let mut config = OpenAIConfig::new().with_api_key(settings.api_key.clone());
+        if let Some(base) = &settings.api_base {
+            config = config.with_api_base(base.clone());
+        }
+        let client = Client::with_config(config);
+
+        Ok(Self {
+            client,
+            model: settings.model.clone(),
+            temperature: settings.temperature,
+            max_tokens: settings.max_tokens,
+            system_prompt: settings.system_prompt.clone(),
+        })
+    }
+
+    fn build_messages(
+        &self,
+        request: &KnowledgeRequest,
+    ) -> Result<Vec<ChatCompletionRequestMessage>, KnowledgeAssistantError> {
+        let mut messages = Vec::new();
+        if let Some(system_prompt) = &self.system_prompt {
+            let system = ChatCompletionRequestSystemMessageArgs::default()
+                .content(system_prompt.clone())
+                .build()
+                .map_err(|err| KnowledgeAssistantError::Request(err.to_string()))?;
+            messages.push(ChatCompletionRequestMessage::System(system));
+        }
+
+        let user_content = format!(
+            "Ontology context: {}\n\n{}\n\nPrompt:\n{}",
+            request.ontology.as_str(),
+            request.context_as_text(),
+            request.prompt
+        );
+        let user = ChatCompletionRequestUserMessageArgs::default()
+            .content(ChatCompletionRequestUserMessageContent::Text(user_content))
+            .build()
+            .map_err(|err| KnowledgeAssistantError::Request(err.to_string()))?;
+        messages.push(ChatCompletionRequestMessage::User(user));
+        Ok(messages)
+    }
+}
+
+#[async_trait]
+impl KnowledgeAssistant for OpenAiKnowledgeAssistant {
+    async fn respond(
+        &self,
+        request: KnowledgeRequest,
+    ) -> Result<KnowledgeResponse, KnowledgeAssistantError> {
+        let messages = self.build_messages(&request)?;
+        let mut builder = CreateChatCompletionRequestArgs::default();
+        builder.model(self.model.clone());
+        builder.messages(messages);
+        if let Some(max_tokens) = self.max_tokens {
+            builder.max_tokens(max_tokens);
+        }
+        if let Some(temperature) = self.temperature {
+            builder.temperature(temperature);
+        }
+        let payload = builder
+            .build()
+            .map_err(|err| KnowledgeAssistantError::Request(err.to_string()))?;
+
+        let response = self
+            .client
+            .chat()
+            .create(payload)
+            .await
+            .map_err(|err| KnowledgeAssistantError::Provider(err.to_string()))?;
+
+        let message = response
+            .choices
+            .into_iter()
+            .find_map(|choice| choice.message.content)
+            .ok_or(KnowledgeAssistantError::EmptyResponse)?;
+
+        Ok(KnowledgeResponse { message })
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -1,0 +1,448 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::{
+    config::{AiSettings, KnowledgeAssistantBackend},
+    ontology::{
+        service::{OntologyServiceError, ReasonerHandle},
+        value_objects::Iri,
+    },
+};
+
+pub mod infrastructure;
+pub mod task;
+
+/// Request issued to a [`KnowledgeAssistant`] implementation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KnowledgeRequest {
+    /// Prompt provided by the caller.
+    pub prompt: String,
+    /// Ontology identifier anchoring the reasoning context.
+    pub ontology: Iri,
+    /// Aggregated reasoning results to be consumed by the assistant.
+    pub inferences: Vec<ReasoningOutcome>,
+}
+
+impl KnowledgeRequest {
+    /// Builds a textual representation of the reasoning context.
+    #[must_use]
+    pub fn context_as_text(&self) -> String {
+        if self.inferences.is_empty() {
+            return String::from("No ontology inferences were requested.");
+        }
+
+        let mut buffer = String::new();
+        for (index, inference) in self.inferences.iter().enumerate() {
+            if index > 0 {
+                buffer.push_str("\n\n");
+            }
+            buffer.push_str(&inference.describe());
+        }
+        buffer
+    }
+}
+
+/// High level response returned by assistant adapters.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KnowledgeResponse {
+    /// Natural language answer returned by the provider.
+    pub message: String,
+}
+
+/// Resulting synthesis combining raw reasoning outputs with the assistant
+/// response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KnowledgeSynthesis {
+    /// Assistant message.
+    pub message: String,
+    /// Reasoning outcomes produced while orchestrating the request.
+    pub inferences: Vec<ReasoningOutcome>,
+}
+
+/// Supported reasoning commands executed before delegating to an assistant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReasoningCommand {
+    /// Fetch the transitive closure of parent classes.
+    Ancestors { class: Iri },
+    /// Fetch the transitive closure of descendant classes.
+    Descendants { class: Iri },
+    /// Retrieve individuals connected through the provided property.
+    RelatedIndividuals { property: Iri, individual: Iri },
+    /// Compute the shortest path between two individuals.
+    ShortestPath { start: Iri, end: Iri },
+}
+
+/// Canonical representation of reasoning outcomes attached to assistant
+/// invocations.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReasoningOutcome {
+    /// Result of [`ReasoningCommand::Ancestors`].
+    Ancestors { class: Iri, ancestors: Vec<Iri> },
+    /// Result of [`ReasoningCommand::Descendants`].
+    Descendants { class: Iri, descendants: Vec<Iri> },
+    /// Result of [`ReasoningCommand::RelatedIndividuals`].
+    RelatedIndividuals {
+        property: Iri,
+        individual: Iri,
+        related: Vec<Iri>,
+    },
+    /// Result of [`ReasoningCommand::ShortestPath`].
+    ShortestPath {
+        start: Iri,
+        end: Iri,
+        path: Option<Vec<Iri>>,
+    },
+}
+
+impl ReasoningOutcome {
+    /// Converts the outcome into a human readable string.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Ancestors { class, ancestors } => {
+                let mut text = format!("Ancestors of class `{class}` ({} items):", ancestors.len());
+                for iri in ancestors {
+                    text.push_str("\n  - ");
+                    text.push_str(iri.as_str());
+                }
+                text
+            }
+            Self::Descendants { class, descendants } => {
+                let mut text = format!(
+                    "Descendants of class `{class}` ({} items):",
+                    descendants.len()
+                );
+                for iri in descendants {
+                    text.push_str("\n  - ");
+                    text.push_str(iri.as_str());
+                }
+                text
+            }
+            Self::RelatedIndividuals {
+                property,
+                individual,
+                related,
+            } => {
+                let mut text = format!(
+                    "Individuals related to `{individual}` via `{property}` ({} items):",
+                    related.len()
+                );
+                for iri in related {
+                    text.push_str("\n  - ");
+                    text.push_str(iri.as_str());
+                }
+                text
+            }
+            Self::ShortestPath { start, end, path } => match path {
+                Some(hops) => {
+                    let mut text = format!(
+                        "Shortest path between `{start}` and `{end}` ({} hops):",
+                        hops.len()
+                    );
+                    for iri in hops {
+                        text.push_str("\n  - ");
+                        text.push_str(iri.as_str());
+                    }
+                    text
+                }
+                None => format!("No path discovered between `{start}` and `{end}`."),
+            },
+        }
+    }
+}
+
+/// Contract implemented by AI providers capable of synthesizing ontology
+/// reasoning results with natural language responses.
+#[async_trait]
+pub trait KnowledgeAssistant: Send + Sync {
+    /// Produces a combined response from the supplied request.
+    async fn respond(
+        &self,
+        request: KnowledgeRequest,
+    ) -> Result<KnowledgeResponse, KnowledgeAssistantError>;
+}
+
+/// Factory error raised when building assistant adapters from configuration.
+#[derive(Debug, Error)]
+pub enum KnowledgeAssistantInitError {
+    /// Configuration referenced an unknown backend.
+    #[error("knowledge assistant backend is not configured")]
+    MissingBackend,
+    /// Provided configuration was invalid.
+    #[error("invalid knowledge assistant configuration: {0}")]
+    InvalidConfiguration(String),
+    /// Adapter construction failed.
+    #[error("failed to construct assistant adapter: {0}")]
+    Adapter(String),
+}
+
+/// Errors surfaced by assistant adapters.
+#[derive(Debug, Error)]
+pub enum KnowledgeAssistantError {
+    /// Building the provider request failed.
+    #[error("failed to compose provider request: {0}")]
+    Request(String),
+    /// Provider returned an invalid response.
+    #[error("provider returned an unexpected response")]
+    EmptyResponse,
+    /// Provider interaction failed.
+    #[error("provider error: {0}")]
+    Provider(String),
+}
+
+/// Orchestrates reasoning commands before delegating to an assistant.
+pub struct KnowledgeOrchestrator {
+    reasoner: Arc<ReasonerHandle>,
+    assistant: Arc<dyn KnowledgeAssistant>,
+}
+
+impl KnowledgeOrchestrator {
+    /// Creates a new orchestrator from its dependencies.
+    pub fn new(reasoner: Arc<ReasonerHandle>, assistant: Arc<dyn KnowledgeAssistant>) -> Self {
+        Self {
+            reasoner,
+            assistant,
+        }
+    }
+
+    /// Executes the supplied reasoning plan before invoking the assistant.
+    pub async fn run(
+        &self,
+        ontology: Iri,
+        prompt: String,
+        plan: Vec<ReasoningCommand>,
+    ) -> Result<KnowledgeSynthesis, KnowledgeOrchestratorError> {
+        let mut inferences = Vec::with_capacity(plan.len());
+        for command in plan {
+            match command {
+                ReasoningCommand::Ancestors { class } => {
+                    let ancestors = self.reasoner.ancestors_of(&ontology, &class).await?;
+                    inferences.push(ReasoningOutcome::Ancestors { class, ancestors });
+                }
+                ReasoningCommand::Descendants { class } => {
+                    let descendants = self.reasoner.descendants_of(&ontology, &class).await?;
+                    inferences.push(ReasoningOutcome::Descendants { class, descendants });
+                }
+                ReasoningCommand::RelatedIndividuals {
+                    property,
+                    individual,
+                } => {
+                    let related = self
+                        .reasoner
+                        .related_individuals(&ontology, &property, &individual)
+                        .await?;
+                    inferences.push(ReasoningOutcome::RelatedIndividuals {
+                        property,
+                        individual,
+                        related,
+                    });
+                }
+                ReasoningCommand::ShortestPath { start, end } => {
+                    let path = self.reasoner.shortest_path(&ontology, &start, &end).await?;
+                    inferences.push(ReasoningOutcome::ShortestPath { start, end, path });
+                }
+            }
+        }
+
+        let request = KnowledgeRequest {
+            prompt,
+            ontology: ontology.clone(),
+            inferences: inferences.clone(),
+        };
+        let response = self.assistant.respond(request).await?;
+        Ok(KnowledgeSynthesis {
+            message: response.message,
+            inferences,
+        })
+    }
+}
+
+/// Errors produced while orchestrating knowledge assistant calls.
+#[derive(Debug, Error)]
+pub enum KnowledgeOrchestratorError {
+    /// Reasoner returned an error while executing the plan.
+    #[error(transparent)]
+    Reasoner(#[from] OntologyServiceError),
+    /// Assistant invocation failed.
+    #[error(transparent)]
+    Assistant(#[from] KnowledgeAssistantError),
+}
+
+/// Builds a knowledge assistant adapter from configuration.
+pub fn build_assistant(
+    settings: &AiSettings,
+) -> Result<Option<Arc<dyn KnowledgeAssistant>>, KnowledgeAssistantInitError> {
+    let Some(backend) = settings.assistant.as_ref() else {
+        return Ok(None);
+    };
+
+    match backend {
+        KnowledgeAssistantBackend::OpenAi(cfg) => {
+            let adapter = infrastructure::openai::OpenAiKnowledgeAssistant::try_new(cfg)?;
+            Ok(Some(Arc::new(adapter)))
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    /// Mock reasoner storing the list of executed operations.
+    #[derive(Default)]
+    pub struct MockReasoner {
+        pub calls: Mutex<Vec<String>>,
+        pub ancestors: Vec<Iri>,
+        pub descendants: Vec<Iri>,
+        pub related: Vec<Iri>,
+        pub path: Option<Vec<Iri>>,
+    }
+
+    #[async_trait]
+    impl crate::ontology::repositories::ReasoningQuery for MockReasoner {
+        type Error = OntologyServiceError;
+
+        async fn ancestors_of(
+            &self,
+            _ontology: &Iri,
+            class: &Iri,
+        ) -> Result<Vec<Iri>, Self::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("ancestors:{class}"));
+            Ok(self.ancestors.clone())
+        }
+
+        async fn descendants_of(
+            &self,
+            _ontology: &Iri,
+            class: &Iri,
+        ) -> Result<Vec<Iri>, Self::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("descendants:{class}"));
+            Ok(self.descendants.clone())
+        }
+
+        async fn related_individuals(
+            &self,
+            _ontology: &Iri,
+            property: &Iri,
+            individual: &Iri,
+        ) -> Result<Vec<Iri>, Self::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("related:{individual}:{property}"));
+            Ok(self.related.clone())
+        }
+
+        async fn shortest_path(
+            &self,
+            _ontology: &Iri,
+            start: &Iri,
+            end: &Iri,
+        ) -> Result<Option<Vec<Iri>>, Self::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("path:{start}:{end}"));
+            Ok(self.path.clone())
+        }
+    }
+
+    /// Mock assistant capturing the last request.
+    pub struct MockAssistant {
+        pub last_request: Mutex<Option<KnowledgeRequest>>,
+        pub response: KnowledgeResponse,
+    }
+
+    impl Default for MockAssistant {
+        fn default() -> Self {
+            Self {
+                last_request: Mutex::new(None),
+                response: KnowledgeResponse {
+                    message: String::new(),
+                },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl KnowledgeAssistant for MockAssistant {
+        async fn respond(
+            &self,
+            request: KnowledgeRequest,
+        ) -> Result<KnowledgeResponse, KnowledgeAssistantError> {
+            *self.last_request.lock().unwrap() = Some(request);
+            Ok(self.response.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn orchestrator_executes_reasoning_plan() {
+        let reasoner = Arc::new(MockReasoner {
+            ancestors: vec![Iri::new("https://example.org/Parent").unwrap()],
+            descendants: vec![],
+            related: vec![],
+            path: Some(vec![Iri::new("https://example.org/path").unwrap()]),
+            ..MockReasoner::default()
+        });
+        let assistant = Arc::new(MockAssistant {
+            response: KnowledgeResponse {
+                message: "ack".to_string(),
+            },
+            ..MockAssistant::default()
+        });
+        let orchestrator = KnowledgeOrchestrator::new(reasoner.clone(), assistant.clone());
+        let ontology = Iri::new("https://example.org/ontology").unwrap();
+        let class = Iri::new("https://example.org/Class").unwrap();
+        let synthesis = orchestrator
+            .run(
+                ontology.clone(),
+                "Explain the hierarchy".to_string(),
+                vec![
+                    ReasoningCommand::Ancestors {
+                        class: class.clone(),
+                    },
+                    ReasoningCommand::ShortestPath {
+                        start: class.clone(),
+                        end: Iri::new("https://example.org/Other").unwrap(),
+                    },
+                ],
+            )
+            .await
+            .expect("orchestrator to succeed");
+
+        assert_eq!(synthesis.message, "ack");
+        assert_eq!(synthesis.inferences.len(), 2);
+        let calls = reasoner.calls.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            [
+                format!("ancestors:{class}"),
+                format!(
+                    "path:{}:{}",
+                    class,
+                    Iri::new("https://example.org/Other").unwrap()
+                ),
+            ]
+        );
+        let recorded = assistant
+            .last_request
+            .lock()
+            .unwrap()
+            .as_ref()
+            .cloned()
+            .expect("request to be recorded");
+        assert_eq!(recorded.prompt, "Explain the hierarchy");
+        assert_eq!(recorded.ontology, ontology);
+        assert_eq!(recorded.inferences.len(), 2);
+    }
+}

--- a/src/ai/task.rs
+++ b/src/ai/task.rs
@@ -1,0 +1,212 @@
+use async_trait::async_trait;
+use tracing::info;
+
+use crate::{
+    ai::{KnowledgeOrchestrator, ReasoningCommand},
+    app::AppContext,
+    ontology::value_objects::Iri,
+    task::{Task, TaskInfo, Vars},
+    Error, Result,
+};
+
+/// Task wiring the ontology reasoner with the configured knowledge assistant.
+#[derive(Default)]
+pub struct KnowledgeTask;
+
+impl KnowledgeTask {
+    fn parse_iri(value: &str, field: &str) -> Result<Iri> {
+        Iri::new(value).map_err(|err| Error::Message(format!("invalid {field} IRI: {err}")))
+    }
+
+    fn build_plan(vars: &Vars) -> Result<Vec<ReasoningCommand>> {
+        let mut plan = Vec::new();
+
+        if let Some(class) = vars.cli.get("class") {
+            let iri = Self::parse_iri(class, "class")?;
+            plan.push(ReasoningCommand::Ancestors { class: iri.clone() });
+            plan.push(ReasoningCommand::Descendants { class: iri });
+        }
+
+        if let (Some(property), Some(individual)) =
+            (vars.cli.get("property"), vars.cli.get("individual"))
+        {
+            plan.push(ReasoningCommand::RelatedIndividuals {
+                property: Self::parse_iri(property, "property")?,
+                individual: Self::parse_iri(individual, "individual")?,
+            });
+        }
+
+        if let (Some(start), Some(end)) = (vars.cli.get("path_start"), vars.cli.get("path_end")) {
+            plan.push(ReasoningCommand::ShortestPath {
+                start: Self::parse_iri(start, "path_start")?,
+                end: Self::parse_iri(end, "path_end")?,
+            });
+        }
+
+        Ok(plan)
+    }
+}
+
+#[async_trait]
+impl Task for KnowledgeTask {
+    fn task(&self) -> TaskInfo {
+        TaskInfo {
+            name: "ontology:assist".to_string(),
+            detail: "Run a reasoning plan and dispatch it to the configured knowledge assistant"
+                .to_string(),
+        }
+    }
+
+    async fn run(&self, app_context: &AppContext, vars: &Vars) -> Result<()> {
+        let prompt = vars.cli_arg("prompt")?.to_string();
+        let ontology_id = vars.cli_arg("ontology")?.to_string();
+        let ontology = Self::parse_iri(&ontology_id, "ontology")?;
+
+        let assistant = app_context
+            .knowledge_assistant
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| {
+                Error::Message(
+                    "knowledge assistant is not configured. Provide `ai.assistant` in the configuration"
+                        .to_string(),
+                )
+            })?;
+
+        let plan = Self::build_plan(vars)?;
+        let reasoner = app_context.ontology.reasoner();
+        let orchestrator = KnowledgeOrchestrator::new(reasoner, assistant);
+        let synthesis = orchestrator
+            .run(ontology, prompt, plan)
+            .await
+            .map_err(Error::wrap)?;
+
+        info!(message = %synthesis.message, "knowledge_assistant_response");
+        for outcome in &synthesis.inferences {
+            info!(context = %outcome.describe(), "knowledge_assistant_reasoning");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai::{
+        test_support::{MockAssistant, MockReasoner},
+        KnowledgeAssistant, KnowledgeResponse,
+    };
+    use crate::config::ReasonerSettings;
+    use crate::ontology::service::OntologyService;
+    use crate::ontology::service::{ReasonerHandle, RepositoryHandle};
+    use crate::tests_cfg;
+    use std::sync::Arc;
+
+    #[derive(Default)]
+    struct NullRepository;
+
+    #[async_trait]
+    impl crate::ontology::repositories::OntologyRepository for NullRepository {
+        type Error = crate::ontology::service::OntologyServiceError;
+
+        async fn insert(
+            &self,
+            _ontology: crate::ontology::entities::Ontology,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn update(
+            &self,
+            _ontology: crate::ontology::entities::Ontology,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn get(
+            &self,
+            _iri: &Iri,
+        ) -> Result<Option<crate::ontology::repositories::OntologySnapshot>, Self::Error> {
+            Ok(None)
+        }
+
+        async fn delete(&self, _iri: &Iri) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn list(
+            &self,
+        ) -> Result<Vec<crate::ontology::repositories::OntologySummary>, Self::Error> {
+            Ok(vec![])
+        }
+
+        async fn attach_class(
+            &self,
+            _ontology: &Iri,
+            _class: crate::ontology::entities::Class,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn attach_property(
+            &self,
+            _ontology: &Iri,
+            _property: crate::ontology::entities::Property,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn attach_individual(
+            &self,
+            _ontology: &Iri,
+            _individual: crate::ontology::entities::Individual,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn task_invokes_orchestrator_with_reasoning_plan() {
+        let reasoner = Arc::new(MockReasoner {
+            ancestors: vec![Iri::new("https://example.org/root").unwrap()],
+            ..MockReasoner::default()
+        });
+        let repository: Arc<RepositoryHandle> = Arc::new(NullRepository::default());
+        let ontology_service = Arc::new(OntologyService::new(
+            repository,
+            reasoner.clone() as Arc<ReasonerHandle>,
+            ReasonerSettings::default(),
+        ));
+
+        let assistant = Arc::new(MockAssistant {
+            response: KnowledgeResponse {
+                message: "ok".to_string(),
+            },
+            ..MockAssistant::default()
+        });
+        let assistant_trait: Arc<dyn KnowledgeAssistant> = assistant.clone();
+
+        let mut ctx = tests_cfg::app::get_app_context().await;
+        ctx.ontology = ontology_service;
+        ctx.knowledge_assistant = Some(assistant_trait);
+
+        let task = KnowledgeTask::default();
+        let vars = Vars::from_cli_args(vec![
+            ("prompt".into(), "Summarize".into()),
+            ("ontology".into(), "https://example.org/ontology".into()),
+            ("class".into(), "https://example.org/root".into()),
+        ]);
+
+        task.run(&ctx, &vars).await.expect("task to succeed");
+        let calls = reasoner.calls.lock().unwrap();
+        assert!(calls.iter().any(|call| call.starts_with("ancestors:")));
+        let request = assistant
+            .last_request
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("assistant request");
+        assert_eq!(request.inferences.len(), 2); // ancestors + descendants
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use axum::Router as AxumRouter;
 use dashmap::DashMap;
 
 use crate::{
+    ai::KnowledgeAssistant,
     bgworker::{self, Queue},
     boot::{shutdown_signal, BootResult, ServeParams, StartMode},
     cache::{self},
@@ -272,6 +273,8 @@ pub struct AppContext {
     pub shared_store: Arc<SharedStore>,
     /// Ontology access layer exposing repository and reasoner adapters.
     pub ontology: Arc<OntologyService>,
+    /// Optional knowledge assistant synthesizing responses.
+    pub knowledge_assistant: Option<Arc<dyn KnowledgeAssistant>>,
 }
 
 /// A trait that defines hooks for customizing and extending the behavior of a

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, info, warn};
 #[cfg(feature = "with-db")]
 use crate::db;
 use crate::{
+    ai,
     app::{AppContext, Hooks, Initializer},
     banner::print_banner,
     bgworker, cache,
@@ -389,6 +390,7 @@ pub async fn create_context<H: Hooks>(
         &config.ontology,
         &config.reasoner,
     )?);
+    let knowledge_assistant = ai::build_assistant(&config.ai).map_err(Error::wrap)?;
     let ctx = AppContext {
         environment: environment.clone(),
         #[cfg(feature = "with-db")]
@@ -400,6 +402,7 @@ pub async fn create_context<H: Hooks>(
         mailer,
         shared_store: Arc::new(crate::app::SharedStore::default()),
         ontology: ontology_service,
+        knowledge_assistant,
     };
 
     H::after_context(ctx).await

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,10 @@ pub struct Config {
     #[serde(default)]
     pub reasoner: ReasonerSettings,
 
+    /// Knowledge assistant configuration for ontology-aware prompts.
+    #[serde(default)]
+    pub ai: AiSettings,
+
     pub scheduler: Option<scheduler::Config>,
 }
 
@@ -621,6 +625,54 @@ impl Default for ReasonerInference {
             property_paths: true,
         }
     }
+}
+
+/// AI assistant configuration controlling the selected provider.
+///
+/// Example configuration:
+/// ```yaml
+/// ai:
+///   assistant:
+///     kind: openai
+///     api_key: ${OPENAI_API_KEY}
+///     model: gpt-4o-mini
+///     temperature: 0.2
+///     max_tokens: 512
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct AiSettings {
+    /// Configured assistant backend.
+    #[serde(default)]
+    pub assistant: Option<KnowledgeAssistantBackend>,
+}
+
+/// Supported knowledge assistant backends.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum KnowledgeAssistantBackend {
+    /// OpenAI chat completion adapter.
+    OpenAi(OpenAiSettings),
+}
+
+/// OpenAI adapter configuration options.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct OpenAiSettings {
+    /// API key used to authenticate against the OpenAI API.
+    pub api_key: String,
+    /// Model identifier powering the responses.
+    pub model: String,
+    /// Optional temperature tuning response creativity.
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    /// Optional response token budget.
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    /// Optional custom API base URL (useful for proxies).
+    #[serde(default)]
+    pub api_base: Option<String>,
+    /// Optional system prompt prepended to every interaction.
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 /// Worker mode configuration

--- a/src/controller/knowledge.rs
+++ b/src/controller/knowledge.rs
@@ -1,0 +1,274 @@
+use axum::{extract::State, routing::post};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ai::{KnowledgeOrchestrator, ReasoningCommand},
+    app::AppContext,
+    controller::{format, Json, Routes},
+    ontology::value_objects::Iri,
+    Error, Result,
+};
+
+#[derive(Deserialize)]
+pub struct KnowledgePrompt {
+    pub ontology: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub reasoning: Vec<ReasoningStep>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum ReasoningStep {
+    Ancestors {
+        class: String,
+    },
+    Descendants {
+        class: String,
+    },
+    RelatedIndividuals {
+        property: String,
+        individual: String,
+    },
+    ShortestPath {
+        start: String,
+        end: String,
+    },
+}
+
+#[derive(Serialize)]
+pub struct KnowledgeResponseBody {
+    pub message: String,
+    pub reasoning: Vec<ReasoningOutcomeView>,
+}
+
+#[derive(Serialize)]
+pub struct ReasoningOutcomeView {
+    pub kind: String,
+    pub summary: String,
+}
+
+impl From<&crate::ai::ReasoningOutcome> for ReasoningOutcomeView {
+    fn from(value: &crate::ai::ReasoningOutcome) -> Self {
+        let kind = match value {
+            crate::ai::ReasoningOutcome::Ancestors { .. } => "ancestors",
+            crate::ai::ReasoningOutcome::Descendants { .. } => "descendants",
+            crate::ai::ReasoningOutcome::RelatedIndividuals { .. } => "related-individuals",
+            crate::ai::ReasoningOutcome::ShortestPath { .. } => "shortest-path",
+        }
+        .to_string();
+
+        Self {
+            kind,
+            summary: value.describe(),
+        }
+    }
+}
+
+impl KnowledgeResponseBody {
+    fn from_synthesis(synthesis: crate::ai::KnowledgeSynthesis) -> Self {
+        let reasoning = synthesis
+            .inferences
+            .iter()
+            .map(ReasoningOutcomeView::from)
+            .collect();
+        Self {
+            message: synthesis.message,
+            reasoning,
+        }
+    }
+}
+
+fn parse_iri(value: &str, field: &str) -> Result<Iri> {
+    Iri::new(value).map_err(|err| Error::BadRequest(format!("invalid {field} IRI: {err}")))
+}
+
+fn build_plan(steps: &[ReasoningStep]) -> Result<Vec<ReasoningCommand>> {
+    let mut plan = Vec::with_capacity(steps.len());
+    for step in steps {
+        match step {
+            ReasoningStep::Ancestors { class } => {
+                plan.push(ReasoningCommand::Ancestors {
+                    class: parse_iri(class, "class")?,
+                });
+            }
+            ReasoningStep::Descendants { class } => {
+                plan.push(ReasoningCommand::Descendants {
+                    class: parse_iri(class, "class")?,
+                });
+            }
+            ReasoningStep::RelatedIndividuals {
+                property,
+                individual,
+            } => {
+                plan.push(ReasoningCommand::RelatedIndividuals {
+                    property: parse_iri(property, "property")?,
+                    individual: parse_iri(individual, "individual")?,
+                });
+            }
+            ReasoningStep::ShortestPath { start, end } => {
+                plan.push(ReasoningCommand::ShortestPath {
+                    start: parse_iri(start, "start")?,
+                    end: parse_iri(end, "end")?,
+                });
+            }
+        }
+    }
+    Ok(plan)
+}
+
+pub async fn invoke(
+    State(ctx): State<AppContext>,
+    Json(payload): Json<KnowledgePrompt>,
+) -> Result<axum::response::Response> {
+    let assistant =
+        ctx.knowledge_assistant.as_ref().cloned().ok_or_else(|| {
+            Error::BadRequest("knowledge assistant is not configured".to_string())
+        })?;
+
+    let ontology = parse_iri(&payload.ontology, "ontology")?;
+    let plan = build_plan(&payload.reasoning)?;
+    let reasoner = ctx.ontology.reasoner();
+    let orchestrator = KnowledgeOrchestrator::new(reasoner, assistant);
+    let synthesis = orchestrator
+        .run(ontology, payload.prompt, plan)
+        .await
+        .map_err(Error::wrap)?;
+
+    format::json(KnowledgeResponseBody::from_synthesis(synthesis))
+}
+
+pub fn routes() -> Routes {
+    Routes::new().add("/ai/knowledge", post(invoke))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::{body, extract::State};
+    use serde_json::json;
+
+    use crate::ai::{
+        test_support::{MockAssistant, MockReasoner},
+        KnowledgeAssistant,
+    };
+    use crate::config::ReasonerSettings;
+    use crate::ontology::service::{OntologyService, ReasonerHandle, RepositoryHandle};
+    use crate::tests_cfg;
+
+    #[derive(Default)]
+    struct NullRepository;
+
+    #[async_trait::async_trait]
+    impl crate::ontology::repositories::OntologyRepository for NullRepository {
+        type Error = crate::ontology::service::OntologyServiceError;
+
+        async fn insert(
+            &self,
+            _ontology: crate::ontology::entities::Ontology,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn update(
+            &self,
+            _ontology: crate::ontology::entities::Ontology,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn get(
+            &self,
+            _iri: &Iri,
+        ) -> Result<Option<crate::ontology::repositories::OntologySnapshot>, Self::Error> {
+            Ok(None)
+        }
+
+        async fn delete(&self, _iri: &Iri) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn list(
+            &self,
+        ) -> Result<Vec<crate::ontology::repositories::OntologySummary>, Self::Error> {
+            Ok(vec![])
+        }
+
+        async fn attach_class(
+            &self,
+            _ontology: &Iri,
+            _class: crate::ontology::entities::Class,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn attach_property(
+            &self,
+            _ontology: &Iri,
+            _property: crate::ontology::entities::Property,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn attach_individual(
+            &self,
+            _ontology: &Iri,
+            _individual: crate::ontology::entities::Individual,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn controller_invokes_assistant() {
+        let reasoner = std::sync::Arc::new(MockReasoner {
+            ancestors: vec![Iri::new("https://example.org/parent").unwrap()],
+            ..MockReasoner::default()
+        });
+        let repository: std::sync::Arc<RepositoryHandle> =
+            std::sync::Arc::new(NullRepository::default());
+        let ontology_service = std::sync::Arc::new(OntologyService::new(
+            repository,
+            reasoner.clone() as std::sync::Arc<ReasonerHandle>,
+            ReasonerSettings::default(),
+        ));
+
+        let assistant = std::sync::Arc::new(MockAssistant {
+            response: crate::ai::KnowledgeResponse {
+                message: "response".to_string(),
+            },
+            ..MockAssistant::default()
+        });
+        let assistant_trait: std::sync::Arc<dyn KnowledgeAssistant> = assistant.clone();
+
+        let mut ctx = tests_cfg::app::get_app_context().await;
+        ctx.ontology = ontology_service;
+        ctx.knowledge_assistant = Some(assistant_trait);
+
+        let body = Json(KnowledgePrompt {
+            ontology: "https://example.org/ontology".to_string(),
+            prompt: "Explain".to_string(),
+            reasoning: vec![ReasoningStep::Ancestors {
+                class: "https://example.org/child".to_string(),
+            }],
+        });
+
+        let response = invoke(State(ctx), body)
+            .await
+            .expect("controller success")
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["message"], json!("response"));
+        assert_eq!(value["reasoning"].as_array().unwrap().len(), 1);
+        let calls = reasoner.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(assistant.last_request.lock().unwrap().is_some());
+    }
+}

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -82,6 +82,7 @@ mod backtrace;
 mod describe;
 pub mod extractor;
 pub mod format;
+pub mod knowledge;
 pub mod middleware;
 pub mod monitoring;
 mod routes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub use self::errors::Error;
 
+pub mod ai;
 mod banner;
 pub mod bgworker;
 mod depcheck;

--- a/src/tests_cfg/app.rs
+++ b/src/tests_cfg/app.rs
@@ -35,5 +35,6 @@ pub async fn get_app_context() -> AppContext {
         cache: cache.into(),
         shared_store: std::sync::Arc::new(SharedStore::default()),
         ontology,
+        knowledge_assistant: None,
     }
 }

--- a/src/tests_cfg/config.rs
+++ b/src/tests_cfg/config.rs
@@ -61,6 +61,7 @@ pub fn test_config() -> Config {
         cache: config::CacheConfig::Null,
         ontology: config::OntologySettings::default(),
         reasoner: config::ReasonerSettings::default(),
+        ai: config::AiSettings::default(),
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce an ai module with knowledge assistant request/orchestrator types and a generic trait
- wire an OpenAI-backed adapter and expose configuration for selecting an assistant backend
- add controller and task entrypoints that coordinate reasoning results with the assistant, including unit tests built on mocks

## Testing
- cargo test *(fails: redis/postgres dependent suites require Docker services)*

------
https://chatgpt.com/codex/tasks/task_e_68ca98d448388333baee5852ce2174e3