### PR TITLE
Add CLI console controller and tests

### DIFF
--- a/src/cli/automation.rs
+++ b/src/cli/automation.rs
@@ -1,6 +1,6 @@
 use crate::introspection::cli::{
     CliCommand, EnqueueJobRequest, ListGeneratorsRequest, ListJobsRequest, ListTasksRequest,
-    RunDoctorRequest, RunGeneratorRequest,
+    RunDoctorRequest, RunGeneratorRequest, RunTaskRequest,
 };
 
 #[derive(Default)]
@@ -38,6 +38,13 @@ impl CargoAutomationCommandBuilder {
     #[must_use]
     pub fn list_tasks(request: &ListTasksRequest) -> CliCommand {
         let args = vec!["loco".into(), "task".into()];
+        Self::build_command(args, request.environment.as_ref())
+    }
+
+    #[must_use]
+    pub fn run_task(request: &RunTaskRequest) -> CliCommand {
+        let mut args = vec!["loco".into(), "task".into(), request.task.clone()];
+        args.extend(request.arguments.clone());
         Self::build_command(args, request.environment.as_ref())
     }
 

--- a/src/controller/cli_console.rs
+++ b/src/controller/cli_console.rs
@@ -1,0 +1,276 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use axum::extract::{Query, State};
+use axum::routing::{get, post};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::{
+    app::AppContext,
+    controller::{format, Json, Routes},
+    errors::Error,
+    introspection::cli::{
+        CliAutomationService, CommandOutput, ListGeneratorsRequest, ListTasksRequest,
+        RunDoctorRequest, RunGeneratorRequest, RunTaskRequest,
+    },
+    Result,
+};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListableCommand {
+    pub command: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GenerationRequest {
+    pub generator: String,
+    #[serde(default)]
+    pub arguments: Vec<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TaskRunRequest {
+    pub task: String,
+    #[serde(default)]
+    pub arguments: Vec<String>,
+    #[serde(default)]
+    pub params: BTreeMap<String, String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DoctorSnapshotRequest {
+    #[serde(default)]
+    pub environment: Option<String>,
+    #[serde(default)]
+    pub production: bool,
+    #[serde(default)]
+    pub config: bool,
+    #[serde(default)]
+    pub graph: bool,
+    #[serde(default)]
+    pub assistant: bool,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct CommandExecution {
+    pub status: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct DoctorSnapshotResponse {
+    pub status: i32,
+    pub stdout: Value,
+    pub stderr: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct AutomationQuery {
+    environment: Option<String>,
+}
+
+pub fn routes() -> Routes {
+    Routes::new()
+        .add("/__loco/cli/generators", get(list_generators))
+        .add("/__loco/cli/generators/run", post(run_generator))
+        .add("/__loco/cli/tasks", get(list_tasks))
+        .add("/__loco/cli/tasks/run", post(run_task))
+        .add("/__loco/cli/doctor/snapshot", post(doctor_snapshot))
+}
+
+pub async fn list_generators(
+    State(ctx): State<AppContext>,
+    Query(query): Query<AutomationQuery>,
+) -> Result<axum::response::Response> {
+    let service = resolve_service(&ctx)?;
+    let request = ListGeneratorsRequest {
+        environment: query.environment,
+    };
+    let output = service.list_generators(&request)?;
+    let commands = parse_listable_commands(&output.stdout);
+    format::json(commands)
+}
+
+pub async fn run_generator(
+    State(ctx): State<AppContext>,
+    Json(payload): Json<GenerationRequest>,
+) -> Result<axum::response::Response> {
+    let service = resolve_service(&ctx)?;
+    let GenerationRequest {
+        generator,
+        arguments,
+        environment,
+    } = payload;
+    let request = RunGeneratorRequest {
+        environment,
+        generator,
+        arguments,
+    };
+    let output = service.run_generator(&request)?;
+    format::json(CommandExecution::from(output))
+}
+
+pub async fn list_tasks(
+    State(ctx): State<AppContext>,
+    Query(query): Query<AutomationQuery>,
+) -> Result<axum::response::Response> {
+    let service = resolve_service(&ctx)?;
+    let request = ListTasksRequest {
+        environment: query.environment,
+    };
+    let output = service.list_tasks(&request)?;
+    let commands = parse_listable_commands(&output.stdout);
+    format::json(commands)
+}
+
+pub async fn run_task(
+    State(ctx): State<AppContext>,
+    Json(payload): Json<TaskRunRequest>,
+) -> Result<axum::response::Response> {
+    let service = resolve_service(&ctx)?;
+    let TaskRunRequest {
+        task,
+        mut arguments,
+        params,
+        environment,
+    } = payload;
+    arguments.extend(
+        params
+            .into_iter()
+            .map(|(key, value)| format!("{key}:{value}")),
+    );
+    let request = RunTaskRequest {
+        environment,
+        task,
+        arguments,
+    };
+    let output = service.run_task(&request)?;
+    format::json(CommandExecution::from(output))
+}
+
+pub async fn doctor_snapshot(
+    State(ctx): State<AppContext>,
+    Json(payload): Json<DoctorSnapshotRequest>,
+) -> Result<axum::response::Response> {
+    let service = resolve_service(&ctx)?;
+    let DoctorSnapshotRequest {
+        environment,
+        production,
+        config,
+        graph,
+        assistant,
+    } = payload;
+    let request = RunDoctorRequest {
+        environment,
+        production,
+        config,
+        graph,
+        assistant,
+    };
+    let output = service.run_doctor(&request)?;
+    format::json(DoctorSnapshotResponse::from(output))
+}
+
+fn resolve_service(ctx: &AppContext) -> Result<Arc<dyn CliAutomationService>> {
+    ctx.shared_store
+        .get_ref::<Arc<dyn CliAutomationService>>()
+        .map(|service| Arc::clone(&*service))
+        .ok_or(Error::NotFound)
+}
+
+fn parse_listable_commands(stdout: &str) -> Vec<ListableCommand> {
+    stdout.lines().filter_map(parse_listable_command).collect()
+}
+
+fn parse_listable_command(line: &str) -> Option<ListableCommand> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.ends_with(':') {
+        return None;
+    }
+    if trimmed.starts_with('-') {
+        return None;
+    }
+
+    let split = trimmed.find(char::is_whitespace)?;
+    let (command, summary) = trimmed.split_at(split);
+    let command = command.trim();
+    let summary = summary.trim();
+
+    if command.is_empty() || summary.is_empty() {
+        return None;
+    }
+
+    Some(ListableCommand {
+        command: command.to_string(),
+        summary: summary.to_string(),
+    })
+}
+
+impl From<CommandOutput> for CommandExecution {
+    fn from(output: CommandOutput) -> Self {
+        let CommandOutput {
+            status,
+            stdout,
+            stderr,
+        } = output;
+        Self {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
+
+impl From<CommandOutput> for DoctorSnapshotResponse {
+    fn from(output: CommandOutput) -> Self {
+        let CommandOutput {
+            status,
+            stdout,
+            stderr,
+        } = output;
+        let stdout_value =
+            serde_json::from_str(&stdout).unwrap_or_else(|_| json!({ "raw": stdout }));
+        Self {
+            status,
+            stdout: stdout_value,
+            stderr,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_listable_command_supports_single_space_separator() {
+        let command = parse_listable_command("model Generates a new model");
+
+        assert_eq!(
+            command,
+            Some(ListableCommand {
+                command: "model".into(),
+                summary: "Generates a new model".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_listable_command_supports_tab_separator() {
+        let command = parse_listable_command("migration\tGenerates a migration");
+
+        assert_eq!(
+            command,
+            Some(ListableCommand {
+                command: "migration".into(),
+                summary: "Generates a migration".into(),
+            })
+        );
+    }
+}

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -79,6 +79,7 @@ use crate::{errors::Error, Result};
 
 mod app_routes;
 mod backtrace;
+pub mod cli_console;
 mod describe;
 pub mod extractor;
 pub mod format;

--- a/src/controller/monitoring.rs
+++ b/src/controller/monitoring.rs
@@ -2,7 +2,7 @@
 //! reporting. These routes are commonly used to monitor the readiness of the
 //! application and its dependencies.
 
-use super::{format, routes::Routes};
+use super::{cli_console, format, routes::Routes};
 
 #[cfg(debug_assertions)]
 use crate::introspection::graph::mutation::{
@@ -166,6 +166,8 @@ pub fn routes() -> Routes {
         .add("/_ping", get(ping))
         .add("/_health", get(health))
         .add("/__loco/graph", get(graph));
+
+    routes = routes.merge(cli_console::routes());
 
     #[cfg(debug_assertions)]
     {

--- a/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]doctor[slash]snapshot].snap
+++ b/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]doctor[slash]snapshot].snap
@@ -1,0 +1,6 @@
+---
+source: src/controller/app_routes.rs
+assertion_line: 334
+expression: "format!(\"{:?} {}\", route.actions, route.uri)"
+---
+"[POST] /__loco/cli/doctor/snapshot"

--- a/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]generators[slash]run].snap
+++ b/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]generators[slash]run].snap
@@ -1,0 +1,6 @@
+---
+source: src/controller/app_routes.rs
+assertion_line: 334
+expression: "format!(\"{:?} {}\", route.actions, route.uri)"
+---
+"[POST] /__loco/cli/generators/run"

--- a/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]generators].snap
+++ b/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]generators].snap
@@ -1,0 +1,6 @@
+---
+source: src/controller/app_routes.rs
+assertion_line: 334
+expression: "format!(\"{:?} {}\", route.actions, route.uri)"
+---
+"[GET] /__loco/cli/generators"

--- a/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]tasks[slash]run].snap
+++ b/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]tasks[slash]run].snap
@@ -1,0 +1,6 @@
+---
+source: src/controller/app_routes.rs
+assertion_line: 334
+expression: "format!(\"{:?} {}\", route.actions, route.uri)"
+---
+"[POST] /__loco/cli/tasks/run"

--- a/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]tasks].snap
+++ b/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]tasks].snap
@@ -1,0 +1,6 @@
+---
+source: src/controller/app_routes.rs
+assertion_line: 334
+expression: "format!(\"{:?} {}\", route.actions, route.uri)"
+---
+"[GET] /__loco/cli/tasks"

--- a/src/introspection/cli/adapters/cargo.rs
+++ b/src/introspection/cli/adapters/cargo.rs
@@ -4,7 +4,7 @@ use crate::cli::automation::CargoAutomationCommandBuilder;
 use crate::introspection::cli::{
     CliAutomationService, CliCommand, CommandExecutor, CommandOutput, EnqueueJobRequest,
     ListGeneratorsRequest, ListJobsRequest, ListTasksRequest, RunDoctorRequest,
-    RunGeneratorRequest,
+    RunGeneratorRequest, RunTaskRequest,
 };
 use crate::{Error, Result};
 
@@ -36,6 +36,11 @@ impl<E: CommandExecutor> CliAutomationService for CargoCliAutomationService<E> {
 
     fn list_tasks(&self, request: &ListTasksRequest) -> Result<CommandOutput> {
         let command = CargoAutomationCommandBuilder::list_tasks(request);
+        self.execute(command)
+    }
+
+    fn run_task(&self, request: &RunTaskRequest) -> Result<CommandOutput> {
+        let command = CargoAutomationCommandBuilder::run_task(request);
         self.execute(command)
     }
 

--- a/src/introspection/cli/mod.rs
+++ b/src/introspection/cli/mod.rs
@@ -60,6 +60,7 @@ pub trait CliAutomationService: Send + Sync {
     fn list_generators(&self, request: &ListGeneratorsRequest) -> Result<CommandOutput>;
     fn run_generator(&self, request: &RunGeneratorRequest) -> Result<CommandOutput>;
     fn list_tasks(&self, request: &ListTasksRequest) -> Result<CommandOutput>;
+    fn run_task(&self, request: &RunTaskRequest) -> Result<CommandOutput>;
     fn list_jobs(&self, request: &ListJobsRequest) -> Result<CommandOutput>;
     fn enqueue_job(&self, request: &EnqueueJobRequest) -> Result<CommandOutput>;
     fn run_doctor(&self, request: &RunDoctorRequest) -> Result<CommandOutput>;
@@ -80,6 +81,13 @@ pub struct RunGeneratorRequest {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ListTasksRequest {
     pub environment: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RunTaskRequest {
+    pub environment: Option<String>,
+    pub task: String,
+    pub arguments: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/tests/controller/cli_console.rs
+++ b/tests/controller/cli_console.rs
@@ -1,0 +1,350 @@
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use axum::{
+    http::StatusCode,
+    routing::{get, post},
+    Router,
+};
+use loco_rs::{
+    app::AppContext,
+    controller::{cli_console, cli_console::ListableCommand},
+    introspection::cli::{
+        CliAutomationService, CommandOutput, ListGeneratorsRequest, ListTasksRequest,
+        RunDoctorRequest, RunGeneratorRequest, RunTaskRequest,
+    },
+    tests_cfg, TestServer,
+};
+use serde_json::json;
+
+fn router_with_state(ctx: AppContext) -> Router {
+    Router::new()
+        .route("/__loco/cli/generators", get(cli_console::list_generators))
+        .route(
+            "/__loco/cli/generators/run",
+            post(cli_console::run_generator),
+        )
+        .route("/__loco/cli/tasks", get(cli_console::list_tasks))
+        .route("/__loco/cli/tasks/run", post(cli_console::run_task))
+        .route(
+            "/__loco/cli/doctor/snapshot",
+            post(cli_console::doctor_snapshot),
+        )
+        .with_state(ctx)
+}
+
+#[derive(Default)]
+struct StubCliAutomationService {
+    list_generators_response: CommandOutput,
+    list_tasks_response: CommandOutput,
+    run_generator_response: CommandOutput,
+    run_task_response: CommandOutput,
+    doctor_response: CommandOutput,
+    list_generators_calls: Mutex<Vec<ListGeneratorsRequest>>,
+    list_tasks_calls: Mutex<Vec<ListTasksRequest>>,
+    run_generator_calls: Mutex<Vec<RunGeneratorRequest>>,
+    run_task_calls: Mutex<Vec<RunTaskRequest>>,
+    doctor_calls: Mutex<Vec<RunDoctorRequest>>,
+}
+
+impl StubCliAutomationService {
+    fn with_list_generators_stdout(stdout: &str) -> Self {
+        Self {
+            list_generators_response: CommandOutput::new(0, stdout, ""),
+            ..Self::default()
+        }
+    }
+
+    fn with_list_tasks_stdout(stdout: &str) -> Self {
+        Self {
+            list_tasks_response: CommandOutput::new(0, stdout, ""),
+            ..Self::default()
+        }
+    }
+
+    fn list_generators_calls(&self) -> Vec<ListGeneratorsRequest> {
+        self.list_generators_calls
+            .lock()
+            .expect("list_generators lock")
+            .clone()
+    }
+
+    fn list_tasks_calls(&self) -> Vec<ListTasksRequest> {
+        self.list_tasks_calls
+            .lock()
+            .expect("list_tasks lock")
+            .clone()
+    }
+
+    fn run_generator_calls(&self) -> Vec<RunGeneratorRequest> {
+        self.run_generator_calls
+            .lock()
+            .expect("run_generator lock")
+            .clone()
+    }
+
+    fn run_task_calls(&self) -> Vec<RunTaskRequest> {
+        self.run_task_calls.lock().expect("run_task lock").clone()
+    }
+
+    fn doctor_calls(&self) -> Vec<RunDoctorRequest> {
+        self.doctor_calls.lock().expect("doctor lock").clone()
+    }
+}
+
+impl CliAutomationService for StubCliAutomationService {
+    fn list_generators(&self, request: &ListGeneratorsRequest) -> loco_rs::Result<CommandOutput> {
+        self.list_generators_calls
+            .lock()
+            .expect("list_generators lock")
+            .push(request.clone());
+        Ok(self.list_generators_response.clone())
+    }
+
+    fn run_generator(&self, request: &RunGeneratorRequest) -> loco_rs::Result<CommandOutput> {
+        self.run_generator_calls
+            .lock()
+            .expect("run_generator lock")
+            .push(request.clone());
+        if self.run_generator_response.status == 0
+            && self.run_generator_response.stdout.is_empty()
+            && self.run_generator_response.stderr.is_empty()
+        {
+            Ok(CommandOutput::default())
+        } else {
+            Ok(self.run_generator_response.clone())
+        }
+    }
+
+    fn list_tasks(&self, request: &ListTasksRequest) -> loco_rs::Result<CommandOutput> {
+        self.list_tasks_calls
+            .lock()
+            .expect("list_tasks lock")
+            .push(request.clone());
+        Ok(self.list_tasks_response.clone())
+    }
+
+    fn list_jobs(
+        &self,
+        _request: &loco_rs::introspection::cli::ListJobsRequest,
+    ) -> loco_rs::Result<CommandOutput> {
+        unimplemented!()
+    }
+
+    fn enqueue_job(
+        &self,
+        _request: &loco_rs::introspection::cli::EnqueueJobRequest,
+    ) -> loco_rs::Result<CommandOutput> {
+        unimplemented!()
+    }
+
+    fn run_doctor(&self, request: &RunDoctorRequest) -> loco_rs::Result<CommandOutput> {
+        self.doctor_calls
+            .lock()
+            .expect("doctor lock")
+            .push(request.clone());
+        Ok(self.doctor_response.clone())
+    }
+
+    fn run_task(&self, request: &RunTaskRequest) -> loco_rs::Result<CommandOutput> {
+        self.run_task_calls
+            .lock()
+            .expect("run_task lock")
+            .push(request.clone());
+        Ok(self.run_task_response.clone())
+    }
+}
+
+fn insert_service(ctx: &AppContext, service: Arc<StubCliAutomationService>) {
+    let automation: Arc<dyn CliAutomationService> = service.clone();
+    ctx.shared_store.insert(automation);
+}
+
+#[tokio::test]
+async fn list_generators_parses_cli_output() {
+    let ctx = tests_cfg::app::get_app_context().await;
+    let service = Arc::new(StubCliAutomationService::with_list_generators_stdout(
+        "Commands:\n  model    Generates a new model\n  migration    Generates a new migration\n",
+    ));
+    insert_service(&ctx, service.clone());
+
+    let router = router_with_state(ctx.clone());
+    let server =
+        TestServer::new(router.into_make_service_with_connect_info::<SocketAddr>()).unwrap();
+
+    let response = server
+        .get("/__loco/cli/generators?environment=development")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    let commands: Vec<ListableCommand> = response.json();
+    assert_eq!(
+        commands,
+        vec![
+            ListableCommand {
+                command: "model".into(),
+                summary: "Generates a new model".into(),
+            },
+            ListableCommand {
+                command: "migration".into(),
+                summary: "Generates a new migration".into(),
+            },
+        ]
+    );
+
+    let calls = service.list_generators_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].environment, Some("development".to_string()));
+}
+
+#[tokio::test]
+async fn run_generator_forwards_payload() {
+    let ctx = tests_cfg::app::get_app_context().await;
+    let service = Arc::new(StubCliAutomationService {
+        run_generator_response: CommandOutput::new(0, "generated", ""),
+        ..StubCliAutomationService::default()
+    });
+    insert_service(&ctx, service.clone());
+
+    let router = router_with_state(ctx.clone());
+    let server =
+        TestServer::new(router.into_make_service_with_connect_info::<SocketAddr>()).unwrap();
+
+    let response = server
+        .post("/__loco/cli/generators/run")
+        .json(&json!({
+            "generator": "model",
+            "arguments": ["posts", "title:string"],
+            "environment": "qa"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    let body = response.json::<serde_json::Value>();
+    assert_eq!(body["status"], 0);
+    assert_eq!(body["stdout"], "generated");
+
+    let calls = service.run_generator_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].generator, "model");
+    assert_eq!(calls[0].arguments, vec!["posts", "title:string"]);
+    assert_eq!(calls[0].environment, Some("qa".into()));
+}
+
+#[tokio::test]
+async fn list_tasks_parses_cli_output() {
+    let ctx = tests_cfg::app::get_app_context().await;
+    let service = Arc::new(StubCliAutomationService::with_list_tasks_stdout(
+        "foo                           [Run foo]\nbar                           [Run bar]\n",
+    ));
+    insert_service(&ctx, service.clone());
+
+    let router = router_with_state(ctx.clone());
+    let server =
+        TestServer::new(router.into_make_service_with_connect_info::<SocketAddr>()).unwrap();
+
+    let response = server.get("/__loco/cli/tasks?environment=staging").await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    let commands: Vec<ListableCommand> = response.json();
+    assert_eq!(
+        commands,
+        vec![
+            ListableCommand {
+                command: "foo".into(),
+                summary: "[Run foo]".into(),
+            },
+            ListableCommand {
+                command: "bar".into(),
+                summary: "[Run bar]".into(),
+            },
+        ]
+    );
+
+    let calls = service.list_tasks_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].environment, Some("staging".into()));
+}
+
+#[tokio::test]
+async fn run_task_merges_arguments_and_params() {
+    let ctx = tests_cfg::app::get_app_context().await;
+    let service = Arc::new(StubCliAutomationService {
+        run_task_response: CommandOutput::new(0, "ran", ""),
+        ..StubCliAutomationService::default()
+    });
+    insert_service(&ctx, service.clone());
+
+    let router = router_with_state(ctx.clone());
+    let server =
+        TestServer::new(router.into_make_service_with_connect_info::<SocketAddr>()).unwrap();
+
+    let response = server
+        .post("/__loco/cli/tasks/run")
+        .json(&json!({
+            "task": "parse_args",
+            "arguments": ["foo:bar"],
+            "params": {"alpha": "one", "beta": "two"},
+            "environment": "test"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    let payload = response.json::<serde_json::Value>();
+    assert_eq!(payload["stdout"], "ran");
+
+    let calls = service.run_task_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].task, "parse_args");
+    assert_eq!(calls[0].environment, Some("test".into()));
+    assert_eq!(calls[0].arguments, vec!["foo:bar", "alpha:one", "beta:two"]);
+}
+
+#[tokio::test]
+async fn doctor_snapshot_parses_json_output() {
+    let ctx = tests_cfg::app::get_app_context().await;
+    let service = Arc::new(StubCliAutomationService {
+        doctor_response: CommandOutput::new(0, "{\"ok\":true}", ""),
+        ..StubCliAutomationService::default()
+    });
+    insert_service(&ctx, service.clone());
+
+    let router = router_with_state(ctx.clone());
+    let server =
+        TestServer::new(router.into_make_service_with_connect_info::<SocketAddr>()).unwrap();
+
+    let response = server
+        .post("/__loco/cli/doctor/snapshot")
+        .json(&json!({"environment": "dev", "graph": true}))
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    let snapshot = response.json::<serde_json::Value>();
+    assert_eq!(snapshot["status"], 0);
+    assert_eq!(snapshot["stdout"], json!({"ok": true}));
+
+    let calls = service.doctor_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].graph, true);
+    assert_eq!(calls[0].environment, Some("dev".into()));
+}
+
+#[tokio::test]
+async fn returns_not_found_when_service_missing() {
+    let ctx = tests_cfg::app::get_app_context().await;
+
+    let router = router_with_state(ctx.clone());
+    let server =
+        TestServer::new(router.into_make_service_with_connect_info::<SocketAddr>()).unwrap();
+
+    let response = server.get("/__loco/cli/generators").await;
+
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+}

--- a/tests/controller/mod.rs
+++ b/tests/controller/mod.rs
@@ -1,3 +1,4 @@
+mod cli_console;
 mod extractor;
 mod graph;
 mod graph_mutation;

--- a/tests/introspection/cli/mod.rs
+++ b/tests/introspection/cli/mod.rs
@@ -4,7 +4,7 @@ use loco_rs::introspection::cli::adapters::cargo::CargoCliAutomationService;
 use loco_rs::introspection::cli::{
     CliAutomationService, CliCommand, CommandExecutor, CommandOutput, EnqueueJobRequest,
     ListGeneratorsRequest, ListJobsRequest, ListTasksRequest, RunDoctorRequest,
-    RunGeneratorRequest,
+    RunGeneratorRequest, RunTaskRequest,
 };
 use loco_rs::Result;
 
@@ -122,6 +122,34 @@ fn list_tasks_honours_environment() {
             "task".to_string(),
             "--environment".to_string(),
             "qa".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn run_task_composes_arguments() {
+    let executor = Arc::new(FakeCommandExecutor::default());
+    let service = service_with_executor(Arc::clone(&executor));
+    let request = RunTaskRequest {
+        environment: Some("dev".into()),
+        task: "parse_args".into(),
+        arguments: vec!["foo:bar".into(), "alpha:one".into()],
+    };
+
+    service.run_task(&request).expect("command to succeed");
+
+    let commands = executor.recorded();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].args,
+        vec![
+            "loco".to_string(),
+            "task".to_string(),
+            "parse_args".to_string(),
+            "foo:bar".to_string(),
+            "alpha:one".to_string(),
+            "--environment".to_string(),
+            "dev".to_string(),
         ]
     );
 }


### PR DESCRIPTION
## Summary
- add a CLI console controller module that exposes generator, task, and doctor endpoints and JSON DTOs
- resolve the automation service from shared state and parse CLI listings more flexibly
- extend monitoring routes and snapshots plus integration tests that exercise the new endpoints and service interactions

## Testing
- cargo fmt
- cargo test
- cargo test controller::app_routes::tests::can_load_app_route_from_default -- --nocapture
- cargo test list_generators_parses_cli_output --test mod -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68cc4647a0308333b5748f504bfe9a50