### PR TITLE
Add CLI job status automation support

### DIFF
--- a/graph-gui/tests/unit/useCommandConsole.test.ts
+++ b/graph-gui/tests/unit/useCommandConsole.test.ts
@@ -85,5 +85,8 @@ describe('useCommandConsole store', () => {
     expect(entry.kind).toBe('job');
     expect(entry.context?.jobId).toBe('job-1');
     expect(entry.status).toBe('success');
+    expect(entry.exitCode).toBe(0);
+    expect(entry.stdout).toBe('done');
+    expect(entry.stderr).toBe('');
   });
 });

--- a/src/bgworker/pg.rs
+++ b/src/bgworker/pg.rs
@@ -573,6 +573,14 @@ pub async fn get_jobs(
     Ok(jobs)
 }
 
+pub async fn find_job(pool: &PgPool, id: &str) -> Result<Option<Job>> {
+    let row = sqlx::query("SELECT * FROM pg_loco_queue WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
+    row.map(|row| to_job(&row)).transpose()
+}
+
 /// Converts a row from the database into a [`Job`] object.
 ///
 /// This function takes a row from the `Postgres` database and manually extracts the necessary

--- a/src/bgworker/redis.rs
+++ b/src/bgworker/redis.rs
@@ -514,6 +514,16 @@ pub async fn get_jobs(
     Ok(jobs)
 }
 
+pub async fn find_job(client: &RedisPool, id: &str) -> Result<Option<Job>> {
+    let mut conn = get_connection(client).await?;
+    let job_key = format!("{JOB_KEY_PREFIX}{id}");
+    let job_json: Option<String> = conn.get(&job_key).await?;
+    match job_json {
+        Some(json) => Job::from_json(&json).map(Some),
+        None => Ok(None),
+    }
+}
+
 // Helper function to check if a job matches the filter criteria
 fn should_include_job(job: &Job, status: Option<&Vec<JobStatus>>, age_days: Option<i64>) -> bool {
     if let Some(status_list) = status {

--- a/src/bgworker/sqlt.rs
+++ b/src/bgworker/sqlt.rs
@@ -662,6 +662,14 @@ pub async fn get_jobs(
     Ok(jobs)
 }
 
+pub async fn find_job(pool: &SqlitePool, id: &str) -> Result<Option<Job>> {
+    let row = sqlx::query("SELECT * FROM sqlt_loco_queue WHERE id = ?")
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
+    row.map(|row| to_job(&row)).transpose()
+}
+
 /// Converts a row from the database into a [`Job`] object.
 ///
 /// This function takes a row from the `SQLite` database and manually extracts the necessary

--- a/src/cli/automation.rs
+++ b/src/cli/automation.rs
@@ -1,6 +1,6 @@
 use crate::introspection::cli::{
-    CliCommand, EnqueueJobRequest, ListGeneratorsRequest, ListJobsRequest, ListTasksRequest,
-    RunDoctorRequest, RunGeneratorRequest, RunTaskRequest,
+    CliCommand, EnqueueJobRequest, JobStatusRequest, ListGeneratorsRequest, ListJobsRequest,
+    ListTasksRequest, RunDoctorRequest, RunGeneratorRequest, RunTaskRequest,
 };
 
 #[derive(Default)]
@@ -91,6 +91,17 @@ impl CargoAutomationCommandBuilder {
             args.push(payload.clone());
         }
         args.extend(request.arguments.clone());
+        Self::build_command(args, request.environment.as_ref())
+    }
+
+    #[must_use]
+    pub fn job_status(request: &JobStatusRequest) -> CliCommand {
+        let args = vec![
+            "loco".into(),
+            "jobs".into(),
+            "status".into(),
+            request.job_id.clone(),
+        ];
         Self::build_command(args, request.environment.as_ref())
     }
 

--- a/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]jobs[slash]{job_id}].snap
+++ b/src/controller/snapshots/loco_rs__controller__app_routes__tests__[[slash]__loco[slash]cli[slash]jobs[slash]{job_id}].snap
@@ -1,0 +1,6 @@
+---
+source: src/controller/app_routes.rs
+assertion_line: 334
+expression: "format!(\"{:?} {}\", route.actions, route.uri)"
+---
+"[GET] /__loco/cli/jobs/{job_id}"

--- a/src/introspection/cli/mod.rs
+++ b/src/introspection/cli/mod.rs
@@ -63,6 +63,7 @@ pub trait CliAutomationService: Send + Sync {
     fn run_task(&self, request: &RunTaskRequest) -> Result<CommandOutput>;
     fn list_jobs(&self, request: &ListJobsRequest) -> Result<CommandOutput>;
     fn enqueue_job(&self, request: &EnqueueJobRequest) -> Result<CommandOutput>;
+    fn job_status(&self, request: &JobStatusRequest) -> Result<JobStatusResponse>;
     fn run_doctor(&self, request: &RunDoctorRequest) -> Result<CommandOutput>;
 }
 
@@ -107,6 +108,21 @@ pub struct EnqueueJobRequest {
     pub tags: Vec<String>,
     pub payload: Option<String>,
     pub arguments: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct JobStatusRequest {
+    pub environment: Option<String>,
+    pub job_id: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct JobStatusResponse {
+    pub id: String,
+    pub state: String,
+    pub result: Option<CommandOutput>,
+    pub error: Option<String>,
+    pub updated_at: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- add job status request/response to CLI automation contract and builder
- implement cargo adapter parsing plus CLI command/query helpers for job status
- expose HTTP console job status route with tests and frontend coverage

## Testing
- `cargo test job_status_parses_cli_output`
- `cargo test job_status_returns_snapshot`
- `cargo test app_routes::tests::can_load_app_route_from_default`
- `pnpm vitest run tests/unit/useCommandConsole.test.ts` *(fails: vitest setup expects global expect)*

------
https://chatgpt.com/codex/tasks/task_e_68cc87cf1c78833381e0b39445708873