### PR TITLE
Fix vitest setup matcher registration

### DIFF
--- a/graph-gui/AGENTS.md
+++ b/graph-gui/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions for `graph-gui`
+
+## Vitest setup
+- Keep `tests/setup.ts` registering Testing Library matchers with a static namespace import: `import * as matchers from '@testing-library/jest-dom/matchers';` followed by `expect.extend(matchers);`. Dynamic imports cause `expect` to be undefined in this environment.
+- When adjusting the Vitest bootstrap, continue to import `expect` directly from `vitest` rather than relying on runtime globals. This prevents `pnpm vitest run tests/unit/useCommandConsole.test.ts` from failing due to `expect.extend` receiving `undefined`.

--- a/graph-gui/tests/setup.ts
+++ b/graph-gui/tests/setup.ts
@@ -1,7 +1,4 @@
-export {};
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { expect } from 'vitest';
 
-if (process?.env?.VITEST) {
-  const { expect } = await import('vitest');
-  const { default: matchers } = await import('@testing-library/jest-dom/matchers');
-  expect.extend(matchers);
-}
+expect.extend(matchers);


### PR DESCRIPTION
## Summary
- import Vitest's expect statically and extend it with the Testing Library matcher namespace to avoid undefined matcher errors
- document the Vitest setup requirement in `graph-gui/AGENTS.md` for future changes

## Testing
- pnpm vitest run tests/unit/useCommandConsole.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd1d241acc83339ad64c7add33a066