### PR TITLE
Document job status console workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ without requiring a running Loco backend.
 
 ## GUI Command Console
 
-The graph visualiser now embeds an interactive console for invoking a curated subset of `cargo loco` commands.
+The graph visualiser now embeds an interactive console for invoking a curated subset of `cargo loco` commands, including job-status lookups that reuse the history viewer for repeated checks.
 The console is available whenever the application is compiled with `debug_assertions` (the default for `cargo run`) and
 can also be enabled in release builds by adding a shared [`CliAutomationService`](./src/controller/cli_console.rs) to the
 application context during bootstrapping.【F:src/controller/cli_console.rs†L83-L104】【F:src/boot.rs†L510-L535】 The optional
@@ -163,6 +163,7 @@ The console understands the following endpoints and mirrors the same parameters 
 * `/__loco/cli/tasks/run` – runs a task, including structured key/value parameters.
 * `/__loco/cli/doctor/snapshot` – runs `cargo loco doctor` and can include the graph snapshot or assistant suggestions when the
   feature flag is enabled.
+* `/__loco/cli/jobs/{job_id}` – fetches the latest status for a scheduler job or queued background task so you can track long-running work without leaving the browser.
 
 Refer to [`docs-site`](./docs-site/content/docs/extras/gui-console.md) for end-to-end setup instructions and security
 hardening tips.

--- a/docs-site/content/docs/extras/gui-console.md
+++ b/docs-site/content/docs/extras/gui-console.md
@@ -7,9 +7,8 @@ template = "docs/page.html"
 
 ## Overview
 
-The graph visualiser ships with an embedded command console that lets you invoke generators, tasks and `cargo loco doctor`
-directly from the browser. Each form mirrors the CLI invocation and persists a compact history, so you can review stdout,
-stderr and exit codes after the command finishes.【F:graph-gui/src/components/CommandConsole.tsx†L42-L149】【F:graph-gui/src/hooks/useCommandConsole.ts†L180-L334】
+The graph visualiser ships with an embedded command console that lets you invoke generators, tasks, `cargo loco doctor`, and job-status lookups directly from the browser. Each form mirrors the CLI invocation and persists a compact history, so you can review stdout,
+stderr and exit codes after the command finishes, or revisit the same entry while polling for job progress.【F:graph-gui/src/components/CommandConsole.tsx†L42-L149】【F:graph-gui/src/hooks/useCommandConsole.ts†L180-L334】
 
 The console issues HTTP requests against the `__loco/cli` endpoints exposed by the framework. The handlers proxy the request to
 your registered `CliAutomationService`, which defaults to the cargo adapter while `debug_assertions` are enabled.【F:src/controller/cli_console.rs†L78-L185】【F:src/boot.rs†L512-L534】 If you build the
@@ -51,6 +50,7 @@ The UI currently calls the following endpoints; you can script against them dire
 * `GET /__loco/cli/tasks` – retrieve available tasks for the chosen environment.
 * `POST /__loco/cli/tasks/run` – execute a task with structured arguments and key/value parameters.
 * `POST /__loco/cli/doctor/snapshot` – run doctor diagnostics and optionally include graph data or assistant suggestions.
+* `GET /__loco/cli/jobs/{job_id}` – retrieve the latest execution details for a scheduler job or background worker task.
 
 All routes accept an optional `environment` field, matching the `--environment` flag provided by `cargo loco` and reflected by the
 console history entries.【F:src/controller/cli_console.rs†L87-L178】【F:graph-gui/src/hooks/useCommandConsole.ts†L180-L349】


### PR DESCRIPTION
## Summary
- document the new job-status lookup workflow supported by the GUI console
- add the /__loco/cli/jobs/{job_id} endpoint to the public endpoint list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cda0a39ed48333ae1da6fe9c4e5cc6